### PR TITLE
fix: Handle undefined title from iNews

### DIFF
--- a/src/@types/inews/index.d.ts
+++ b/src/@types/inews/index.d.ts
@@ -19,7 +19,7 @@ declare module 'inews' {
 		 * 	but may be used in blueprints - installation / organisation dependent.
 		 */
 		interface INewsFields {
-			title: string
+			title: string | undefined
 			modifyDate: string // number
 			pageNumber?: string
 			tapeTime: string // number

--- a/src/@types/inews/index.d.ts
+++ b/src/@types/inews/index.d.ts
@@ -19,7 +19,7 @@ declare module 'inews' {
 		 * 	but may be used in blueprints - installation / organisation dependent.
 		 */
 		interface INewsFields {
-			title: string | undefined
+			title: string
 			modifyDate: string // number
 			pageNumber?: string
 			tapeTime: string // number

--- a/src/classes/RundownManager.ts
+++ b/src/classes/RundownManager.ts
@@ -83,7 +83,7 @@ export class RundownManager {
 				if (rawSegment) {
 					const segment: UnrankedSegment = {
 						externalId: rawSegment.identifier,
-						name: rawSegment.fields.title,
+						name: rawSegment.fields.title || '',
 						modified: ParseDateFromInews(rawSegment.fields.modifyDate),
 						locator: rawSegment.locator,
 						rundownId: queueName,

--- a/src/classes/__tests__/__mocks__/mockSegments.ts
+++ b/src/classes/__tests__/__mocks__/mockSegments.ts
@@ -78,7 +78,7 @@ export function RundownSegmentFromMockSegment(
 		segmentGW.locator,
 		segmentGW.identifier,
 		0,
-		segmentGW.fields.title,
+		segmentGW.fields.title || '',
 		untimed
 	)
 }

--- a/src/helpers/ResolveRundownIntoPlaylist.ts
+++ b/src/helpers/ResolveRundownIntoPlaylist.ts
@@ -26,17 +26,18 @@ export function ResolveRundownIntoPlaylist(
 
 	for (const segment of segments) {
 		currentRundown.segments.push(segment.externalId)
-		if (!klarOnAirStoryFound && segment.name.match(/klar[\s-]*on[\s-]*air/im)) {
+		if (!klarOnAirStoryFound && isSegmentTitleReadyOnAir(segment)) {
 			klarOnAirStoryFound = true
 			untimedSegments.add(segment.externalId)
 		}
 		// TODO: Not relevant for breaks
-		if (!continuityStoryFound && segment.name.match(/^\s*continuity\s*$/i)) {
+		if (!continuityStoryFound && isSegmentTitleContinuity(segment)) {
 			continuityStoryFound = true
-			if (segment.iNewsStory.fields.backTime?.match(/^@\d+$/)) {
+			if (isSegmentBackTimeCorrectFormat(segment)) {
 				currentRundown.backTime = segment.iNewsStory.fields.backTime
 			}
 		}
+
 		if (continuityStoryFound) {
 			untimedSegments.add(segment.externalId)
 		}
@@ -58,4 +59,18 @@ export function ResolveRundownIntoPlaylist(
 	}
 
 	return { resolvedPlaylist, untimedSegments }
+}
+
+function isSegmentTitleReadyOnAir(segment: UnrankedSegment): boolean {
+	return /klar[\s-]*on[\s-]*air/im.test(segment.name)
+}
+
+function isSegmentTitleContinuity(segment: UnrankedSegment): boolean {
+	return /^\s*continuity\s*$/i.test(segment.name)
+}
+
+function isSegmentBackTimeCorrectFormat(segment: UnrankedSegment): boolean {
+	const backTime: string = segment.iNewsStory.fields.backTime ? segment.iNewsStory.fields.backTime : ''
+	const atSignWithNumbers: RegExp = /^@\d+$/
+	return atSignWithNumbers.test(backTime)
 }

--- a/src/helpers/__tests__/ResolveRundownIntoPlaylist.spec.ts
+++ b/src/helpers/__tests__/ResolveRundownIntoPlaylist.spec.ts
@@ -87,6 +87,33 @@ function createKlarOnAirSegment(num: number, backTime?: string): UnrankedSegment
 	})
 }
 
+function createUnnamedSegment(num: number): UnrankedSegment {
+	let id = num.toString().padStart(2, '0')
+	return literal<UnrankedSegment>({
+		externalId: `segment-${id}`,
+		name: '',
+		modified: new Date(),
+		locator: '',
+		rundownId: 'test-rundown',
+		iNewsStory: literal<INewsStory>({
+			id,
+			identifier: id,
+			locator: '',
+			fields: literal<INewsFields>({
+				title: '',
+				modifyDate: '',
+				tapeTime: '',
+				audioTime: '',
+				totalTime: '',
+				cumeTime: '',
+			}),
+			meta: {},
+			cues: [],
+			body: '',
+		}),
+	})
+}
+
 describe('Resolve Rundown Into Playlist', () => {
 	it('Creates a playlist with one rundown when no back-time is present', () => {
 		let segments: Array<UnrankedSegment> = [
@@ -221,6 +248,24 @@ describe('Resolve Rundown Into Playlist', () => {
 			untimedSegments: new Set(['segment-02']),
 		})
 	})
+
+	it('tests that a segment with blank name does not break the parser', () => {
+		let segments: Array<UnrankedSegment> = [createUnnamedSegment(1)]
+
+		const result = ResolveRundownIntoPlaylist('test-playlist', segments)
+
+		expect(result).toEqual({
+			resolvedPlaylist: literal<ResolvedPlaylist>([
+				{
+					rundownId: 'test-playlist_1',
+					segments: ['segment-01'],
+				},
+			]),
+			untimedSegments: new Set([]),
+		})
+	})
+
+	// todo - create object with undefined Segment name
 
 	// TODO: Breaks, future work
 	/*it('Splits with one segment with back-time', () => {

--- a/src/helpers/__tests__/ResolveRundownIntoPlaylist.spec.ts
+++ b/src/helpers/__tests__/ResolveRundownIntoPlaylist.spec.ts
@@ -87,11 +87,11 @@ function createKlarOnAirSegment(num: number, backTime?: string): UnrankedSegment
 	})
 }
 
-function createUnnamedSegment(num: number): UnrankedSegment {
+function createUnnamedSegment(num: number, segmentName: any): UnrankedSegment {
 	let id = num.toString().padStart(2, '0')
 	return literal<UnrankedSegment>({
 		externalId: `segment-${id}`,
-		name: '',
+		name: segmentName,
 		modified: new Date(),
 		locator: '',
 		rundownId: 'test-rundown',
@@ -250,7 +250,23 @@ describe('Resolve Rundown Into Playlist', () => {
 	})
 
 	it('tests that a segment with blank name does not break the parser', () => {
-		let segments: Array<UnrankedSegment> = [createUnnamedSegment(1)]
+		let segments: Array<UnrankedSegment> = [createUnnamedSegment(1, '')]
+
+		const result = ResolveRundownIntoPlaylist('test-playlist', segments)
+
+		expect(result).toEqual({
+			resolvedPlaylist: literal<ResolvedPlaylist>([
+				{
+					rundownId: 'test-playlist_1',
+					segments: ['segment-01'],
+				},
+			]),
+			untimedSegments: new Set([]),
+		})
+	})
+
+	it('tests that a segment with undefined name does not break the parser', () => {
+		let segments: Array<UnrankedSegment> = [createUnnamedSegment(1, undefined)]
 
 		const result = ResolveRundownIntoPlaylist('test-playlist', segments)
 


### PR DESCRIPTION
When creating a new segment in inews without a title it will be passed to the gateways as undefined. Segment name will then become undefined even though the model does not allow it and that will cause errors.