### PR TITLE
fix: Another implementation of "Handle undefined title from iNews"

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "buildinspect:dev": "yarn build && DEV=true yarn inspect",
     "build:main": "tsc -p tsconfig.json",
     "lint": "prettier --check .",
+    "lint-fix": "prettier --write .",
     "unit": "jest",
     "test": "yarn lint && yarn unit",
     "test:integration": "yarn lint && jest --config=jest-integration.config.js",

--- a/src/@types/inews/index.d.ts
+++ b/src/@types/inews/index.d.ts
@@ -19,13 +19,13 @@ declare module 'inews' {
 		 * 	but may be used in blueprints - installation / organisation dependent.
 		 */
 		interface INewsFields {
-			title: string
-			modifyDate: string // number
+			title?: string
+			modifyDate?: string // number
 			pageNumber?: string
-			tapeTime: string // number
-			audioTime: string // number
-			totalTime: string // number
-			cumeTime: string // number
+			tapeTime?: string // number
+			audioTime?: string // number
+			totalTime?: string // number
+			cumeTime?: string // number
 			backTime?: string // @number (seconds since midnight)
 		}
 

--- a/src/classes/RundownManager.ts
+++ b/src/classes/RundownManager.ts
@@ -3,7 +3,7 @@ import { INewsClient, INewsStory, INewsDirItem, INewsFile } from 'inews'
 import { promisify } from 'util'
 import { INewsStoryGW } from './datastructures/Segment'
 import { ReducedRundown, ReducedSegment, UnrankedSegment } from './RundownWatcher'
-import { literal, ParseModifiedDateFromInewsStoryWithFallbackToNow, ReflectPromise } from '../helpers'
+import { literal, parseModifiedDateFromInewsStoryWithFallbackToNow, ReflectPromise } from '../helpers'
 import { VERSION } from '../version'
 import { SegmentId } from '../helpers/id'
 
@@ -84,7 +84,7 @@ export class RundownManager {
 					const segment: UnrankedSegment = {
 						externalId: rawSegment.identifier,
 						name: rawSegment.fields.title ?? '',
-						modified: ParseModifiedDateFromInewsStoryWithFallbackToNow(rawSegment),
+						modified: parseModifiedDateFromInewsStoryWithFallbackToNow(rawSegment),
 						locator: rawSegment.locator,
 						rundownId: queueName,
 						iNewsStory: rawSegment,

--- a/src/classes/RundownManager.ts
+++ b/src/classes/RundownManager.ts
@@ -83,8 +83,7 @@ export class RundownManager {
 				if (rawSegment) {
 					const segment: UnrankedSegment = {
 						externalId: rawSegment.identifier,
-						name: rawSegment.fields.title,
-						modified: ParseDateFromInews(rawSegment.fields.modifyDate),
+						name: rawSegment.fields.title || '',
 						modified: ParseDateFromInews(rawSegment.fields.modifyDate || '') || new Date(),
 						locator: rawSegment.locator,
 						rundownId: queueName,

--- a/src/classes/RundownManager.ts
+++ b/src/classes/RundownManager.ts
@@ -3,7 +3,7 @@ import { INewsClient, INewsStory, INewsDirItem, INewsFile } from 'inews'
 import { promisify } from 'util'
 import { INewsStoryGW } from './datastructures/Segment'
 import { ReducedRundown, ReducedSegment, UnrankedSegment } from './RundownWatcher'
-import { literal, ParseDateFromInews, ReflectPromise } from '../helpers'
+import { literal, ParseModifiedDateFromInewsStoryWithFallbackToNow, ReflectPromise } from '../helpers'
 import { VERSION } from '../version'
 import { SegmentId } from '../helpers/id'
 
@@ -83,9 +83,8 @@ export class RundownManager {
 				if (rawSegment) {
 					const segment: UnrankedSegment = {
 						externalId: rawSegment.identifier,
-						name: rawSegment.fields.title || '',
-						modified: ParseDateFromInews(rawSegment.fields.modifyDate || '') || new Date(),
 						name: rawSegment.fields.title ?? '',
+						modified: ParseModifiedDateFromInewsStoryWithFallbackToNow(rawSegment),
 						locator: rawSegment.locator,
 						rundownId: queueName,
 						iNewsStory: rawSegment,

--- a/src/classes/RundownManager.ts
+++ b/src/classes/RundownManager.ts
@@ -50,7 +50,7 @@ export class RundownManager {
 						literal<ReducedSegment>({
 							externalId: ftpFileName.identifier,
 							name: ftpFileName.storyName,
-							modified: ftpFileName.modified || new Date(0),
+							modified: ftpFileName.modified ?? new Date(0),
 							locator: ftpFileName.locator,
 							rank: index,
 						})

--- a/src/classes/RundownManager.ts
+++ b/src/classes/RundownManager.ts
@@ -85,6 +85,7 @@ export class RundownManager {
 						externalId: rawSegment.identifier,
 						name: rawSegment.fields.title || '',
 						modified: ParseDateFromInews(rawSegment.fields.modifyDate || '') || new Date(),
+						name: rawSegment.fields.title ?? '',
 						locator: rawSegment.locator,
 						rundownId: queueName,
 						iNewsStory: rawSegment,

--- a/src/classes/RundownManager.ts
+++ b/src/classes/RundownManager.ts
@@ -85,6 +85,7 @@ export class RundownManager {
 						externalId: rawSegment.identifier,
 						name: rawSegment.fields.title,
 						modified: ParseDateFromInews(rawSegment.fields.modifyDate),
+						modified: ParseDateFromInews(rawSegment.fields.modifyDate || '') || new Date(),
 						locator: rawSegment.locator,
 						rundownId: queueName,
 						iNewsStory: rawSegment,

--- a/src/classes/__tests__/__mocks__/mockSegments.ts
+++ b/src/classes/__tests__/__mocks__/mockSegments.ts
@@ -74,11 +74,11 @@ export function RundownSegmentFromMockSegment(
 	return new RundownSegment(
 		rundownId,
 		_.clone(segmentGW),
-		new Date(segmentGW.fields.modifyDate),
+		new Date(segmentGW.fields.modifyDate || ''),
 		segmentGW.locator,
 		segmentGW.identifier,
 		0,
-		segmentGW.fields.title,
+		segmentGW.fields.title || '',
 		untimed
 	)
 }

--- a/src/classes/__tests__/__mocks__/mockSegments.ts
+++ b/src/classes/__tests__/__mocks__/mockSegments.ts
@@ -74,11 +74,11 @@ export function RundownSegmentFromMockSegment(
 	return new RundownSegment(
 		rundownId,
 		_.clone(segmentGW),
-		new Date(segmentGW.fields.modifyDate || ''),
+		new Date(segmentGW.fields.modifyDate ?? ''),
 		segmentGW.locator,
 		segmentGW.identifier,
 		0,
-		segmentGW.fields.title || '',
+		segmentGW.fields.title ?? '',
 		untimed
 	)
 }

--- a/src/classes/__tests__/__mocks__/mockSegments.ts
+++ b/src/classes/__tests__/__mocks__/mockSegments.ts
@@ -1,7 +1,7 @@
 import { INewsStoryGW, RundownSegment } from '../../datastructures/Segment'
 import * as _ from 'underscore'
 import { ReducedSegment } from '../../RundownWatcher'
-import { ParseModifiedDateFromInewsStoryWithFallbackToNow } from '../../../helpers'
+import { parseModifiedDateFromInewsStoryWithFallbackToNow } from '../../../helpers'
 
 export const segmentGW01: ReducedSegment = {
 	name: 'Segment 01',
@@ -72,7 +72,7 @@ export function RundownSegmentFromMockSegment(
 	segmentGW: INewsStoryGW,
 	untimed: boolean
 ): RundownSegment {
-	const modifiedDate = ParseModifiedDateFromInewsStoryWithFallbackToNow(segmentGW)
+	const modifiedDate = parseModifiedDateFromInewsStoryWithFallbackToNow(segmentGW)
 
 	return new RundownSegment(
 		rundownId,

--- a/src/classes/__tests__/__mocks__/mockSegments.ts
+++ b/src/classes/__tests__/__mocks__/mockSegments.ts
@@ -1,6 +1,7 @@
 import { INewsStoryGW, RundownSegment } from '../../datastructures/Segment'
 import * as _ from 'underscore'
 import { ReducedSegment } from '../../RundownWatcher'
+import { ParseModifiedDateFromInewsStoryWithFallbackToNow } from '../../../helpers'
 
 export const segmentGW01: ReducedSegment = {
 	name: 'Segment 01',
@@ -71,10 +72,12 @@ export function RundownSegmentFromMockSegment(
 	segmentGW: INewsStoryGW,
 	untimed: boolean
 ): RundownSegment {
+	const modifiedDate = ParseModifiedDateFromInewsStoryWithFallbackToNow(segmentGW)
+
 	return new RundownSegment(
 		rundownId,
 		_.clone(segmentGW),
-		new Date(segmentGW.fields.modifyDate ?? ''),
+		modifiedDate,
 		segmentGW.locator,
 		segmentGW.identifier,
 		0,

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -13,7 +13,7 @@ function isValidDate(d: Date) {
 	return !isNaN(d.getTime())
 }
 
-export function ParseModifiedDateFromInewsStoryWithFallbackToNow(story: INewsStory) {
+export function parseModifiedDateFromInewsStoryWithFallbackToNow(story: INewsStory) {
 	if (story?.fields?.modifyDate) {
 		const modifyDate = new Date(story?.fields?.modifyDate)
 		if (isValidDate(modifyDate)) {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,3 +1,6 @@
+import { INewsStory } from 'inews'
+import { IngestSegment } from '@sofie-automation/blueprints-integration'
+
 export function literal<T>(o: T) {
 	return o
 }
@@ -10,10 +13,28 @@ function isValidDate(d: Date) {
 	return !isNaN(d.getTime())
 }
 
-export function ParseDateFromInews(date: string) {
-	const modifyDate = new Date(date)
+export function ParseModifiedDateFromInewsStoryWithFallbackToNow(story: INewsStory) {
+	if (story?.fields?.modifyDate) {
+		const modifyDate = new Date(story?.fields?.modifyDate)
+		if (isValidDate(modifyDate)) {
+			return modifyDate
+		}
+	}
 
-	return isValidDate(modifyDate) ? modifyDate : undefined
+	// fall back to "now"
+	return new Date()
+}
+
+export function ParseModifiedDateFromIngestSegmentWithFallbackToNow(segment: IngestSegment) {
+	if (segment?.payload?.modified) {
+		const modifyDate = new Date(segment?.payload?.modified)
+		if (isValidDate(modifyDate)) {
+			return modifyDate
+		}
+	}
+
+	// fall back to "now"
+	return new Date()
 }
 
 export function ReflectPromise<T>(

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -13,7 +13,7 @@ function isValidDate(d: Date) {
 	return !isNaN(d.getTime())
 }
 
-export function parseModifiedDateFromInewsStoryWithFallbackToNow(story: INewsStory) {
+export function parseModifiedDateFromInewsStoryWithFallbackToNow(story: INewsStory): Date {
 	if (story?.fields?.modifyDate) {
 		const modifyDate = new Date(story?.fields?.modifyDate)
 		if (isValidDate(modifyDate)) {
@@ -25,7 +25,7 @@ export function parseModifiedDateFromInewsStoryWithFallbackToNow(story: INewsSto
 	return new Date()
 }
 
-export function ParseModifiedDateFromIngestSegmentWithFallbackToNow(segment: IngestSegment) {
+export function parseModifiedDateFromIngestSegmentWithFallbackToNow(segment: IngestSegment): Date {
 	if (segment?.payload?.modified) {
 		const modifyDate = new Date(segment?.payload?.modified)
 		if (isValidDate(modifyDate)) {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -6,14 +6,14 @@ export function assertUnreachable(_never: never): never {
 	throw new Error('Switch validation failed, look for assertUnreachable(...)')
 }
 
-function isValidDate(d: unknown) {
-	return d instanceof Date
+function isValidDate(d: Date) {
+	return !isNaN(d.getTime())
 }
 
 export function ParseDateFromInews(date: string) {
 	const modifyDate = new Date(date)
 
-	return isValidDate(modifyDate) ? modifyDate : new Date()
+	return isValidDate(modifyDate) ? modifyDate : undefined
 }
 
 export function ReflectPromise<T>(

--- a/src/helpers/ResolveRundownIntoPlaylist.ts
+++ b/src/helpers/ResolveRundownIntoPlaylist.ts
@@ -26,12 +26,12 @@ export function ResolveRundownIntoPlaylist(
 
 	for (const segment of segments) {
 		currentRundown.segments.push(segment.externalId)
-		if (!klarOnAirStoryFound && segment.name.match(/klar[\s-]*on[\s-]*air/im)) {
+		if (!klarOnAirStoryFound && segment.name?.match(/klar[\s-]*on[\s-]*air/im)) {
 			klarOnAirStoryFound = true
 			untimedSegments.add(segment.externalId)
 		}
 		// TODO: Not relevant for breaks
-		if (!continuityStoryFound && segment.name.match(/^\s*continuity\s*$/i)) {
+		if (!continuityStoryFound && segment.name?.match(/^\s*continuity\s*$/i)) {
 			continuityStoryFound = true
 			if (segment.iNewsStory.fields.backTime?.match(/^@\d+$/)) {
 				currentRundown.backTime = segment.iNewsStory.fields.backTime

--- a/src/helpers/__tests__/ResolveRundownIntoPlaylist.spec.ts
+++ b/src/helpers/__tests__/ResolveRundownIntoPlaylist.spec.ts
@@ -87,6 +87,33 @@ function createKlarOnAirSegment(num: number, backTime?: string): UnrankedSegment
 	})
 }
 
+function createUnnamedSegment(num: number, segmentName: any): UnrankedSegment {
+	let id = num.toString().padStart(2, '0')
+	return literal<UnrankedSegment>({
+		externalId: `segment-${id}`,
+		name: segmentName,
+		modified: new Date(),
+		locator: '',
+		rundownId: 'test-rundown',
+		iNewsStory: literal<INewsStory>({
+			id,
+			identifier: id,
+			locator: '',
+			fields: literal<INewsFields>({
+				title: '',
+				modifyDate: '',
+				tapeTime: '',
+				audioTime: '',
+				totalTime: '',
+				cumeTime: '',
+			}),
+			meta: {},
+			cues: [],
+			body: '',
+		}),
+	})
+}
+
 describe('Resolve Rundown Into Playlist', () => {
 	it('Creates a playlist with one rundown when no back-time is present', () => {
 		let segments: Array<UnrankedSegment> = [
@@ -221,6 +248,40 @@ describe('Resolve Rundown Into Playlist', () => {
 			untimedSegments: new Set(['segment-02']),
 		})
 	})
+
+	it('tests that a segment with blank name does not break the parser', () => {
+		let segments: Array<UnrankedSegment> = [createUnnamedSegment(1, '')]
+
+		const result = ResolveRundownIntoPlaylist('test-playlist', segments)
+
+		expect(result).toEqual({
+			resolvedPlaylist: literal<ResolvedPlaylist>([
+				{
+					rundownId: 'test-playlist_1',
+					segments: ['segment-01'],
+				},
+			]),
+			untimedSegments: new Set([]),
+		})
+	})
+
+	it('tests that a segment with undefined name does not break the parser', () => {
+		let segments: Array<UnrankedSegment> = [createUnnamedSegment(1, undefined)]
+
+		const result = ResolveRundownIntoPlaylist('test-playlist', segments)
+
+		expect(result).toEqual({
+			resolvedPlaylist: literal<ResolvedPlaylist>([
+				{
+					rundownId: 'test-playlist_1',
+					segments: ['segment-01'],
+				},
+			]),
+			untimedSegments: new Set([]),
+		})
+	})
+
+	// todo - create object with undefined Segment name
 
 	// TODO: Breaks, future work
 	/*it('Splits with one segment with back-time', () => {

--- a/src/mutate.ts
+++ b/src/mutate.ts
@@ -45,7 +45,7 @@ export function IngestSegmentToRundownSegment(ingestSegment: IngestSegment): Run
 	return new RundownSegment(
 		rundownId,
 		inewsStory,
-		ParseDateFromInews(modified),
+		ParseDateFromInews(modified) || new Date(),
 		locator,
 		ingestSegment.externalId,
 		ingestSegment.rank,

--- a/src/mutate.ts
+++ b/src/mutate.ts
@@ -2,7 +2,7 @@ import * as _ from 'underscore'
 import { IngestPlaylist, IngestRundown, IngestSegment } from '@sofie-automation/blueprints-integration'
 import { RundownSegment, ISegment } from './classes/datastructures/Segment'
 import { ReducedPlaylist, ReducedRundown } from './classes/RundownWatcher'
-import { ParseModifiedDateFromIngestSegmentWithFallbackToNow } from './helpers'
+import { parseModifiedDateFromIngestSegmentWithFallbackToNow } from './helpers'
 
 export const INGEST_RUNDOWN_TYPE = 'inews'
 
@@ -45,7 +45,7 @@ export function IngestSegmentToRundownSegment(ingestSegment: IngestSegment): Run
 	return new RundownSegment(
 		rundownId,
 		inewsStory,
-		ParseModifiedDateFromIngestSegmentWithFallbackToNow(modified),
+		parseModifiedDateFromIngestSegmentWithFallbackToNow(modified),
 		locator,
 		ingestSegment.externalId,
 		ingestSegment.rank,

--- a/src/mutate.ts
+++ b/src/mutate.ts
@@ -2,7 +2,7 @@ import * as _ from 'underscore'
 import { IngestPlaylist, IngestRundown, IngestSegment } from '@sofie-automation/blueprints-integration'
 import { RundownSegment, ISegment } from './classes/datastructures/Segment'
 import { ReducedPlaylist, ReducedRundown } from './classes/RundownWatcher'
-import { ParseDateFromInews } from './helpers'
+import { ParseModifiedDateFromIngestSegmentWithFallbackToNow } from './helpers'
 
 export const INGEST_RUNDOWN_TYPE = 'inews'
 
@@ -45,7 +45,7 @@ export function IngestSegmentToRundownSegment(ingestSegment: IngestSegment): Run
 	return new RundownSegment(
 		rundownId,
 		inewsStory,
-		ParseDateFromInews(modified) || new Date(),
+		ParseModifiedDateFromIngestSegmentWithFallbackToNow(modified),
 		locator,
 		ingestSegment.externalId,
 		ingestSegment.rank,


### PR DESCRIPTION
Replacing #29 which says "When creating a new segment in inews without a title it will be passed to the gateways as undefined. Segment name will then become undefined even though the model does not allow it and that will cause errors."