### PR TITLE
fix: clear queues to avoid memory leak

### DIFF
--- a/src/@types/inews/index.d.ts
+++ b/src/@types/inews/index.d.ts
@@ -74,10 +74,10 @@ declare module 'inews' {
 		type status = 'connecting' | 'connected' | 'error' | 'disconnected'
 
 		interface INewsClient extends EventEmitter {
-			/* _queue: { // Expose queue so if can be flsuhed after used
-				queuedJobList: { list: object },
+			_queue: {
+				queuedJobList: { list: object }
 				inprogressJobList: { list: object }
-			} */
+			}
 			list(queneName: string, cb: (error: Error | null, dirList: Array<INewsDirItem>) => void): void
 			story(queueName: string, file: string, cb: (error: Error | null, rawStory: INewsStory) => void): void
 			storyNsml(queueName: string, file: string, cb: (error: Error | null, nsml: string) => void): void

--- a/src/classes/RundownManager.ts
+++ b/src/classes/RundownManager.ts
@@ -143,4 +143,11 @@ export class RundownManager {
 			return Promise.reject(`Cannot find rundown with Id ${queueName}`)
 		}
 	}
+
+	emptyInewsFtpBuffer() {
+		if (this.inewsConnection) {
+			this.inewsConnection._queue.queuedJobList.list = {}
+			this.inewsConnection._queue.inprogressJobList.list = {}
+		}
+	}
 }

--- a/src/classes/RundownWatcher.ts
+++ b/src/classes/RundownWatcher.ts
@@ -241,6 +241,8 @@ export class RundownWatcher extends EventEmitter {
 					if (this.handler.isConnected) {
 						await this.coreHandler.setStatus(P.StatusCode.GOOD, [])
 					}
+
+					this.rundownManager.emptyInewsFtpBuffer()
 				},
 				async (error) => {
 					this.logger.error('Something went wrong during check', error, error.stack)


### PR DESCRIPTION
Data was stacking up in the JobQueue library this project is using. It looks like objects in inprogressJobList are never removed.
Haven't been able to figure out if we are using the lib incorrect or if it's a bug in that lib.
Clearing the JobQueue seems to fix it.
This fix have existed in the project before but was removed for some reason in 2019.