### PR TITLE
fix: the gateway will now set it's status to bad

### DIFF
--- a/src/coreHandler.ts
+++ b/src/coreHandler.ts
@@ -75,7 +75,6 @@ export class CoreHandler {
 		})
 		this.core.onDisconnected(() => {
 			this.logger.info('Core Disconnected!')
-			this.setStatus(P.StatusCode.WARNING_MAJOR, ['Core Disconnected'])
 		})
 		this.core.onError((err) => {
 			this.logger.error('Core Error: ' + (err.message || err.toString() || err))

--- a/src/coreHandler.ts
+++ b/src/coreHandler.ts
@@ -172,6 +172,7 @@ export class CoreHandler {
 		await this.setupSubscriptionsAndObservers().catch((e) => {
 			this.logger.error('setupSubscriptionsAndObservers error', e, e.stack)
 		})
+		this.iNewsHandler?.restartWatcher()
 	}
 	/**
 	 * Called when connected to core.

--- a/src/coreHandler.ts
+++ b/src/coreHandler.ts
@@ -75,9 +75,11 @@ export class CoreHandler {
 		})
 		this.core.onDisconnected(() => {
 			this.logger.info('Core Disconnected!')
+			this.setStatus(P.StatusCode.WARNING_MAJOR, ['Core Disconnected'])
 		})
 		this.core.onError((err) => {
 			this.logger.error('Core Error: ' + (err.message || err.toString() || err))
+			this.setStatus(P.StatusCode.BAD, ['Core error'])
 		})
 
 		let ddpConfig: DDPConnectorOptions = {
@@ -200,10 +202,13 @@ export class CoreHandler {
 			this.core.autoSubscribe('ingestDataCache', {}),
 		])
 		this._subscriptions = this._subscriptions.concat(subs)
+		this.logger.info('Core: Setting up observers for peripheral device commands on ' + this.core.deviceId + '..')
 		this.setupObserverForPeripheralDeviceCommands() // Sets up observers
+		this.logger.info('Core: Execute peripheral device commands on ' + this.core.deviceId + '..')
 		this.executePeripheralDeviceCommands().catch((e) =>
 			this.logger.error(`executePeripheralDeviceCommands error`, e, e.stack)
 		) // Runs any commands async
+		this.logger.info('Core: Setting up observers for peripheral devices on ' + this.core.deviceId + '..')
 		this.setupObserverForPeripheralDevices()
 	}
 	/**

--- a/src/coreHandler.ts
+++ b/src/coreHandler.ts
@@ -201,13 +201,10 @@ export class CoreHandler {
 			this.core.autoSubscribe('ingestDataCache', {}),
 		])
 		this._subscriptions = this._subscriptions.concat(subs)
-		this.logger.info('Core: Setting up observers for peripheral device commands on ' + this.core.deviceId + '..')
 		this.setupObserverForPeripheralDeviceCommands() // Sets up observers
-		this.logger.info('Core: Execute peripheral device commands on ' + this.core.deviceId + '..')
 		this.executePeripheralDeviceCommands().catch((e) =>
 			this.logger.error(`executePeripheralDeviceCommands error`, e, e.stack)
 		) // Runs any commands async
-		this.logger.info('Core: Setting up observers for peripheral devices on ' + this.core.deviceId + '..')
 		this.setupObserverForPeripheralDevices()
 	}
 	/**
@@ -270,6 +267,7 @@ export class CoreHandler {
 	 */
 	// Made async as it does async work ...
 	setupObserverForPeripheralDeviceCommands() {
+		this.logger.info('Core: Setting up observers for peripheral device commands on ' + this.core.deviceId + '..')
 		let observer = this.core.observe('peripheralDeviceCommands')
 		this.killProcess(0) // just make sure it exists
 		this._observers.push(observer)
@@ -306,6 +304,7 @@ export class CoreHandler {
 	 *  Execute all relevant commands now
 	 */
 	async executePeripheralDeviceCommands(): Promise<void> {
+		this.logger.info('Core: Execute peripheral device commands on ' + this.core.deviceId + '..')
 		let cmds = this.core.getCollection('peripheralDeviceCommands')
 		if (!cmds) throw Error('"peripheralDeviceCommands" collection not found!')
 		await Promise.all(
@@ -323,6 +322,7 @@ export class CoreHandler {
 	 * Subscribes to changes to the device to get its associated studio ID.
 	 */
 	setupObserverForPeripheralDevices() {
+		this.logger.info('Core: Setting up observers for peripheral devices on ' + this.core.deviceId + '..')
 		// Setup observer.
 		let observer = this.core.observe('peripheralDevices')
 		this.killProcess(0)

--- a/src/inewsHandler.ts
+++ b/src/inewsHandler.ts
@@ -227,4 +227,9 @@ export class InewsFTPHandler {
 				this._coreHandler.core.callMethod(P.methods.dataSegmentRanksUpdate, [rundownExteralId, newRanks])
 			})
 	}
+
+	restartWatcher(): void {
+		this._logger.info(`Restarting watchers`)
+		this.iNewsWatcher?.startWatcher()
+	}
 }


### PR DESCRIPTION
The gateway will now set it's status to bad when CoreConnection fails with an error or warning if the core is disconnected from inews.
Also added som more logging to help figure out where in the connection process inews stalled as reported in https://tv2cms.atlassian.net/browse/SOF-812