### PR TITLE
refactor: Renamed graphics profile to showstyle variant where appropriate

### DIFF
--- a/src/helpers/ResolveRundownIntoPlaylist.ts
+++ b/src/helpers/ResolveRundownIntoPlaylist.ts
@@ -77,11 +77,11 @@ function extractAndSetShowstyleVariant(segment: UnrankedSegment, rundown: Resolv
 	const showstyleVariants = getOrderedShowstyleVariants(segment)
 	if (showstyleVariants.length > 0) {
 		const showstyleVariant = showstyleVariants[0]
-		setGraphicsProfile(rundown, showstyleVariant)
+		setShowstyleVariant(rundown, showstyleVariant)
 	}
 }
 
-function setGraphicsProfile(rundown: ResolvedPlaylistRundown, showstyleVariant: string) {
+function setShowstyleVariant(rundown: ResolvedPlaylistRundown, showstyleVariant: string) {
 	rundown.payload = {
 		...(rundown.payload ?? null),
 		showstyleVariant,
@@ -99,7 +99,7 @@ function getOrderedShowstyleVariants(segment: UnrankedSegment): string[] {
 	const cueOrder = getCueOrder(segment)
 	const orderedShowstyleVariants: string[] = []
 	cueOrder.forEach((cueIndex: number) => {
-		const parsedProfile = parseGraphicsProfile(segment.iNewsStory.cues[cueIndex])
+		const parsedProfile = parseShowstyleVariant(segment.iNewsStory.cues[cueIndex])
 		if (parsedProfile) {
 			orderedShowstyleVariants.push(parsedProfile)
 		}
@@ -107,7 +107,7 @@ function getOrderedShowstyleVariants(segment: UnrankedSegment): string[] {
 	return orderedShowstyleVariants
 }
 
-function parseGraphicsProfile(cue: UnparsedCue | undefined): string | null {
+function parseShowstyleVariant(cue: UnparsedCue | undefined): string | null {
 	const numberOfCueLines = !!cue ? cue.length : -1
 
 	// Kommando cue (ignoring timing)

--- a/src/helpers/__tests__/DiffPlaylist.spec.ts
+++ b/src/helpers/__tests__/DiffPlaylist.spec.ts
@@ -551,7 +551,7 @@ describe('DiffPlaylist', () => {
 		})
 	})
 
-	it('tests if adding a graphic profile triggers update meta data', () => {
+	it('tests if adding a showstyle variant triggers update meta data', () => {
 		let prevPlaylist = [
 			makeINewsRundown('test-rundown_1', [
 				{
@@ -603,7 +603,7 @@ describe('DiffPlaylist', () => {
 		})
 	})
 
-	it('tests that keeping a graphic profile does not trigger any updates.', () => {
+	it('tests that keeping a showstyle variant does not trigger any updates.', () => {
 		let prevPlaylist = [
 			makeINewsRundown(
 				'test-rundown_1',
@@ -656,7 +656,7 @@ describe('DiffPlaylist', () => {
 		})
 	})
 
-	it('tests if changing a graphic profile triggers update meta data', () => {
+	it('tests if changing a showstyle variant triggers update meta data', () => {
 		let prevPlaylist = [
 			makeINewsRundown(
 				'test-rundown_1',
@@ -714,7 +714,7 @@ describe('DiffPlaylist', () => {
 		})
 	})
 
-	it('tests if deleting a graphic profile triggers update meta data', () => {
+	it('tests if deleting a showstyle variant triggers update meta data', () => {
 		let prevPlaylist = [
 			makeINewsRundown(
 				'test-rundown_1',

--- a/src/helpers/__tests__/ResolveRundownIntoPlaylist.spec.ts
+++ b/src/helpers/__tests__/ResolveRundownIntoPlaylist.spec.ts
@@ -292,7 +292,7 @@ describe('Resolve Rundown Into Playlist', () => {
 		})
 	})
 
-	it('tests that a KLAR ON AIR with GRAPHICSPROFILE sets the rundown showstyleVariant', () => {
+	it('tests that a KLAR ON AIR with ShowstyleVariant sets the rundown showstyleVariant', () => {
 		const segments = [
 			createUnrankedSegment(1),
 			createKlarOnAirSegment(2, {
@@ -314,7 +314,7 @@ describe('Resolve Rundown Into Playlist', () => {
 		})
 	})
 
-	it('tests that only the first KLAR ON AIR with GRAPHICSPROFILE sets the rundown showstyleVariant', () => {
+	it('tests that only the first KLAR ON AIR with ShowstyleVariant sets the rundown showstyleVariant', () => {
 		const segments = [
 			createUnrankedSegment(1),
 			createKlarOnAirSegment(2, {
@@ -397,7 +397,7 @@ describe('Resolve Rundown Into Playlist', () => {
 		})
 	})
 
-	it('tests that we pick the first graphics profile cue', () => {
+	it('tests that we pick the first showstyle variant cue', () => {
 		const segments = [
 			createKlarOnAirSegment(1, {
 				cues: [


### PR DESCRIPTION
When going from graphics profile cue to sofie showstylevariant cue, not all function names were updated.
This is fixed now.