### PR TITLE
SOF-907: missing rundown ranks

### DIFF
--- a/src/helpers/ResolveRundownIntoPlaylist.ts
+++ b/src/helpers/ResolveRundownIntoPlaylist.ts
@@ -38,8 +38,12 @@ export function ResolveRundownIntoPlaylist(
 
 	for (const segment of segments) {
 		if (shouldLookForGraphicProfile(segment, currentRundown)) {
-			splitRundown()
-			extractAndSetGraphicProfile(segment, currentRundown)
+			const graphicProfiles = getOrderedGraphicProfiles(segment)
+			if (graphicProfiles.length > 0) {
+				splitRundown()
+				const graphicProfile = graphicProfiles[0]
+				setGraphicProfile(currentRundown, graphicProfile)
+			}
 		}
 
 		currentRundown.segments.push(segment.externalId)
@@ -74,15 +78,7 @@ function isKlarOnAir(segment: UnrankedSegment): boolean {
 	return !!segment.name?.match(klarOnAirPattern)
 }
 
-function extractAndSetGraphicProfile(segment: UnrankedSegment, rundown: ResolvedPlaylistRundown): void {
-	const graphicProfiles = getOrderedGraphicProfiles(segment)
-	if (graphicProfiles.length > 0) {
-		const graphicProfile = graphicProfiles[0]
-		setGraphicsProfile(rundown, graphicProfile)
-	}
-}
-
-function setGraphicsProfile(rundown: ResolvedPlaylistRundown, graphicProfile: string) {
+function setGraphicProfile(rundown: ResolvedPlaylistRundown, graphicProfile: string) {
 	rundown.payload = {
 		...(rundown.payload ?? null),
 		graphicProfile,
@@ -98,7 +94,7 @@ function getOrderedGraphicProfiles(segment: UnrankedSegment): string[] {
 	const cueOrder = getCueOrder(segment)
 	const orderedGraphicProfiles: string[] = []
 	cueOrder.forEach((cueIndex: number) => {
-		const parsedProfile = parseGraphicsProfile(segment.iNewsStory.cues[cueIndex])
+		const parsedProfile = parseGraphicProfile(segment.iNewsStory.cues[cueIndex])
 		if (parsedProfile) {
 			orderedGraphicProfiles.push(parsedProfile)
 		}
@@ -106,7 +102,7 @@ function getOrderedGraphicProfiles(segment: UnrankedSegment): string[] {
 	return orderedGraphicProfiles
 }
 
-function parseGraphicsProfile(cue: UnparsedCue | undefined): string | null {
+function parseGraphicProfile(cue: UnparsedCue | undefined): string | null {
 	const numberOfCueLines = !!cue ? cue.length : -1
 
 	// Kommando cue (ignoring timing)

--- a/src/helpers/ResolveRundownIntoPlaylist.ts
+++ b/src/helpers/ResolveRundownIntoPlaylist.ts
@@ -108,8 +108,7 @@ function parseGraphicProfile(cue: UnparsedCue | undefined): string | null {
 	// Kommando cue (ignoring timing)
 	const kommandoPattern = /^\s*KOMMANDO\s*=\s*GRAPHICSPROFILE/i
 	if (numberOfCueLines >= 2 && kommandoPattern.test(cue![0])) {
-		const graphicProfile = cue![1].trim()
-		return graphicProfile
+		return cue![1].trim()
 	}
 	return null
 }

--- a/src/helpers/ResolveRundownIntoPlaylist.ts
+++ b/src/helpers/ResolveRundownIntoPlaylist.ts
@@ -23,21 +23,22 @@ export function ResolveRundownIntoPlaylist(
 		segments: [],
 	}
 
-	// TODO: Use for creating multi-rundown playlists
-	// const splitRundown = () => {
-	// 	resolvedPlaylist.push(currentRundown)
-	// 	rundownIndex++
-	// 	currentRundown = {
-	// 		rundownId: `${playlistExternalId}_${rundownIndex + 1}`,
-	// 		segments: [],
-	// 	}
-	// }
+	const splitRundown = () => {
+		if (currentRundown.segments.length === 0) return
+		resolvedPlaylist.push(currentRundown)
+		rundownIndex++
+		currentRundown = {
+			rundownId: `${playlistExternalId}_${rundownIndex + 1}`,
+			segments: [],
+		}
+	}
 
 	let continuityStoryFound = false
 	let klarOnAirStoryFound = false
 
 	for (const segment of segments) {
 		if (shouldLookForGraphicProfile(segment, currentRundown)) {
+			splitRundown()
 			extractAndSetGraphicProfile(segment, currentRundown)
 		}
 
@@ -89,10 +90,8 @@ function setGraphicsProfile(rundown: ResolvedPlaylistRundown, graphicProfile: st
 }
 
 function shouldLookForGraphicProfile(segment: UnrankedSegment, rundown: ResolvedPlaylistRundown): boolean {
-	const isKlarOnAirSegment = isKlarOnAir(segment)
 	const isFloated = segment.iNewsStory.meta.float ?? false
-	const rundownHasGraphicProfile = rundown?.payload?.graphicProfile !== undefined
-	return !isFloated && isKlarOnAirSegment && !rundownHasGraphicProfile
+	return !isFloated
 }
 
 function getOrderedGraphicProfiles(segment: UnrankedSegment): string[] {

--- a/src/helpers/ResolveRundownIntoPlaylist.ts
+++ b/src/helpers/ResolveRundownIntoPlaylist.ts
@@ -89,7 +89,7 @@ function setGraphicsProfile(rundown: ResolvedPlaylistRundown, graphicProfile: st
 	}
 }
 
-function shouldLookForGraphicProfile(segment: UnrankedSegment, rundown: ResolvedPlaylistRundown): boolean {
+function shouldLookForGraphicProfile(segment: UnrankedSegment, _rundown: ResolvedPlaylistRundown): boolean {
 	const isFloated = segment.iNewsStory.meta.float ?? false
 	return !isFloated
 }

--- a/src/helpers/ResolveRundownIntoPlaylist.ts
+++ b/src/helpers/ResolveRundownIntoPlaylist.ts
@@ -21,6 +21,9 @@ export function ResolveRundownIntoPlaylist(
 	let currentRundown: ResolvedPlaylistRundown = {
 		rundownId: `${playlistExternalId}_${rundownIndex + 1}`, // 1-index for users
 		segments: [],
+		payload: {
+			rank: 0,
+		},
 	}
 
 	const splitRundown = () => {
@@ -30,6 +33,9 @@ export function ResolveRundownIntoPlaylist(
 		currentRundown = {
 			rundownId: `${playlistExternalId}_${rundownIndex + 1}`,
 			segments: [],
+			payload: {
+				rank: rundownIndex,
+			},
 		}
 	}
 

--- a/src/helpers/__tests__/ResolveRundownIntoPlaylist.spec.ts
+++ b/src/helpers/__tests__/ResolveRundownIntoPlaylist.spec.ts
@@ -140,6 +140,7 @@ describe('Resolve Rundown Into Playlist', () => {
 				{
 					rundownId: 'test-playlist_1',
 					segments: ['segment-01', 'segment-02', 'segment-03'],
+					payload: { rank: 0 },
 				},
 			]),
 			untimedSegments: new Set(),
@@ -162,6 +163,7 @@ describe('Resolve Rundown Into Playlist', () => {
 					rundownId: 'test-playlist_1',
 					segments: ['segment-01', 'segment-02', 'segment-03', 'segment-04'],
 					backTime: '@1234',
+					payload: { rank: 0 },
 				},
 			]),
 			untimedSegments: new Set(['segment-04']),
@@ -185,6 +187,7 @@ describe('Resolve Rundown Into Playlist', () => {
 					rundownId: 'test-playlist_1',
 					segments: ['segment-01', 'segment-02', 'segment-03', 'segment-04', 'segment-05'],
 					backTime: '@1234',
+					payload: { rank: 0 },
 				},
 			]),
 			untimedSegments: new Set(['segment-04', 'segment-05']),
@@ -209,6 +212,7 @@ describe('Resolve Rundown Into Playlist', () => {
 					rundownId: 'test-playlist_1',
 					segments: ['segment-01', 'segment-02', 'segment-03', 'segment-04', 'segment-05', 'segment-06'],
 					backTime: '@1234',
+					payload: { rank: 0 },
 				},
 			]),
 			untimedSegments: new Set(['segment-04', 'segment-05', 'segment-06']),
@@ -232,6 +236,7 @@ describe('Resolve Rundown Into Playlist', () => {
 				{
 					rundownId: 'test-playlist_1',
 					segments: ['segment-01', 'segment-02', 'segment-03', 'segment-04', 'segment-05', 'segment-06'],
+					payload: { rank: 0 },
 				},
 			]),
 			untimedSegments: new Set(['segment-04', 'segment-05', 'segment-06']),
@@ -254,6 +259,7 @@ describe('Resolve Rundown Into Playlist', () => {
 				{
 					rundownId: 'test-playlist_1',
 					segments: ['segment-01', 'segment-02', 'segment-03', 'segment-04', 'segment-05'],
+					payload: { rank: 0 },
 				},
 			]),
 			untimedSegments: new Set(['segment-02']),
@@ -270,6 +276,7 @@ describe('Resolve Rundown Into Playlist', () => {
 				{
 					rundownId: 'test-playlist_1',
 					segments: ['segment-01'],
+					payload: { rank: 0 },
 				},
 			]),
 			untimedSegments: new Set([]),
@@ -286,6 +293,7 @@ describe('Resolve Rundown Into Playlist', () => {
 				{
 					rundownId: 'test-playlist_1',
 					segments: ['segment-01'],
+					payload: { rank: 0 },
 				},
 			]),
 			untimedSegments: new Set([]),
@@ -307,11 +315,12 @@ describe('Resolve Rundown Into Playlist', () => {
 				{
 					rundownId: 'test-playlist_1',
 					segments: ['segment-01'],
+					payload: { rank: 0 },
 				},
 				{
 					rundownId: 'test-playlist_2',
 					segments: ['segment-02'],
-					payload: { showstyleVariant: 'TV2 Nyhederne' },
+					payload: { showstyleVariant: 'TV2 Nyhederne', rank: 1 },
 				},
 			]),
 			untimedSegments: new Set(['segment-02']),
@@ -338,16 +347,17 @@ describe('Resolve Rundown Into Playlist', () => {
 				{
 					rundownId: 'test-playlist_1',
 					segments: ['segment-01'],
+					payload: { rank: 0 },
 				},
 				{
 					rundownId: 'test-playlist_2',
 					segments: ['segment-02', 'segment-03'],
-					payload: { showstyleVariant: 'TV2 Nyhederne' },
+					payload: { showstyleVariant: 'TV2 Nyhederne', rank: 1 },
 				},
 				{
 					rundownId: 'test-playlist_3',
 					segments: ['segment-04'],
-					payload: { showstyleVariant: 'TV2 Sporten' },
+					payload: { showstyleVariant: 'TV2 Sporten', rank: 2 },
 				},
 			]),
 			untimedSegments: new Set(['segment-02']),
@@ -373,16 +383,17 @@ describe('Resolve Rundown Into Playlist', () => {
 				{
 					rundownId: 'test-playlist_1',
 					segments: ['segment-01'],
+					payload: { rank: 0 },
 				},
 				{
 					rundownId: 'test-playlist_2',
 					segments: ['segment-02'],
-					payload: { showstyleVariant: 'TV2 Nyhederne' },
+					payload: { showstyleVariant: 'TV2 Nyhederne', rank: 1 },
 				},
 				{
 					rundownId: 'test-playlist_3',
 					segments: ['segment-03'],
-					payload: { showstyleVariant: 'TV2 Sporten' },
+					payload: { showstyleVariant: 'TV2 Sporten', rank: 2 },
 				},
 			]),
 			untimedSegments: new Set([]),
@@ -413,16 +424,17 @@ describe('Resolve Rundown Into Playlist', () => {
 				{
 					rundownId: 'test-playlist_1',
 					segments: ['segment-01'],
+					payload: { rank: 0 },
 				},
 				{
 					rundownId: 'test-playlist_2',
 					segments: ['segment-02'],
-					payload: { showstyleVariant: 'TV2 Nyhederne' },
+					payload: { showstyleVariant: 'TV2 Nyhederne', rank: 1 },
 				},
 				{
 					rundownId: 'test-playlist_3',
 					segments: ['segment-03'],
-					payload: { showstyleVariant: 'TV2 Sporten' },
+					payload: { showstyleVariant: 'TV2 Sporten', rank: 2 },
 				},
 			]),
 			untimedSegments: new Set(['segment-02']),
@@ -451,7 +463,7 @@ describe('Resolve Rundown Into Playlist', () => {
 				{
 					rundownId: 'test-playlist_1',
 					segments: ['segment-01'],
-					payload: { showstyleVariant: 'TV2 Sporten' },
+					payload: { showstyleVariant: 'TV2 Sporten', rank: 0 },
 				},
 			]),
 			untimedSegments: new Set(['segment-01']),
@@ -478,11 +490,12 @@ describe('Resolve Rundown Into Playlist', () => {
 				{
 					rundownId: 'test-playlist_1',
 					segments: ['segment-01', 'segment-02'],
+					payload: { rank: 0 },
 				},
 				{
 					rundownId: 'test-playlist_2',
 					segments: ['segment-03'],
-					payload: { showstyleVariant: 'TV2 Sporten' },
+					payload: { showstyleVariant: 'TV2 Sporten', rank: 1 },
 				},
 			]),
 			untimedSegments: new Set(),
@@ -509,6 +522,7 @@ describe('Resolve Rundown Into Playlist', () => {
 				{
 					rundownId: 'test-playlist_1',
 					segments: ['segment-01', 'segment-02', 'segment-03'],
+					payload: { rank: 0 },
 				},
 			]),
 			untimedSegments: new Set(['segment-03']),
@@ -535,6 +549,7 @@ describe('Resolve Rundown Into Playlist', () => {
 				{
 					rundownId: 'test-playlist_1',
 					segments: ['segment-01', 'segment-02', 'segment-03'],
+					payload: { rank: 0 },
 				},
 			]),
 			untimedSegments: new Set(['segment-03']),
@@ -561,6 +576,7 @@ describe('Resolve Rundown Into Playlist', () => {
 				{
 					rundownId: 'test-playlist_1',
 					segments: ['segment-01', 'segment-02', 'segment-03'],
+					payload: { rank: 0 },
 				},
 			]),
 			untimedSegments: new Set(['segment-03']),

--- a/src/helpers/__tests__/ResolveRundownIntoPlaylist.spec.ts
+++ b/src/helpers/__tests__/ResolveRundownIntoPlaylist.spec.ts
@@ -292,7 +292,7 @@ describe('Resolve Rundown Into Playlist', () => {
 		})
 	})
 
-	it('tests that a KLAR ON AIR with GRAPHICSPROFILE sets the rundown graphicProfile (kommando)', () => {
+	it('tests that a KLAR ON AIR with GRAPHICSPROFILE sets the rundown graphicProfile', () => {
 		const segments = [
 			createUnrankedSegment(1),
 			createKlarOnAirSegment(2, {
@@ -306,7 +306,11 @@ describe('Resolve Rundown Into Playlist', () => {
 			resolvedPlaylist: literal<ResolvedPlaylist>([
 				{
 					rundownId: 'test-playlist_1',
-					segments: ['segment-01', 'segment-02'],
+					segments: ['segment-01'],
+				},
+				{
+					rundownId: 'test-playlist_2',
+					segments: ['segment-02'],
 					payload: { graphicProfile: 'TV2 Nyhederne' },
 				},
 			]),
@@ -314,7 +318,7 @@ describe('Resolve Rundown Into Playlist', () => {
 		})
 	})
 
-	it('tests that only the first KLAR ON AIR with GRAPHICSPROFILE sets the rundown graphicProfile (kommando)', () => {
+	it('tests that only the first KLAR ON AIR with GRAPHICSPROFILE sets the rundown graphicProfile', () => {
 		const segments = [
 			createUnrankedSegment(1),
 			createKlarOnAirSegment(2, {
@@ -333,15 +337,24 @@ describe('Resolve Rundown Into Playlist', () => {
 			resolvedPlaylist: literal<ResolvedPlaylist>([
 				{
 					rundownId: 'test-playlist_1',
-					segments: ['segment-01', 'segment-02', 'segment-03', 'segment-04'],
+					segments: ['segment-01'],
+				},
+				{
+					rundownId: 'test-playlist_2',
+					segments: ['segment-02', 'segment-03'],
 					payload: { graphicProfile: 'TV2 Nyhederne' },
+				},
+				{
+					rundownId: 'test-playlist_3',
+					segments: ['segment-04'],
+					payload: { graphicProfile: 'TV2 Sporten' },
 				},
 			]),
 			untimedSegments: new Set(['segment-02']),
 		})
 	})
 
-	it('tests that we can only set graphicProfile from KLAR ON AIR (kommando)', () => {
+	it('tests that we can set graphicProfile in non KLAR-ON-AIR stories', () => {
 		const segments = [
 			createUnrankedSegment(1),
 			createUnrankedSegment(2, {
@@ -359,14 +372,24 @@ describe('Resolve Rundown Into Playlist', () => {
 			resolvedPlaylist: literal<ResolvedPlaylist>([
 				{
 					rundownId: 'test-playlist_1',
-					segments: ['segment-01', 'segment-02', 'segment-03'],
+					segments: ['segment-01'],
+				},
+				{
+					rundownId: 'test-playlist_2',
+					segments: ['segment-02'],
+					payload: { graphicProfile: 'TV2 Nyhederne' },
+				},
+				{
+					rundownId: 'test-playlist_3',
+					segments: ['segment-03'],
+					payload: { graphicProfile: 'TV2 Sporten' },
 				},
 			]),
 			untimedSegments: new Set([]),
 		})
 	})
 
-	it('tests that we only care about the first cue (kommando)', () => {
+	it('tests that we only care about the first cue', () => {
 		const segments = [
 			createUnrankedSegment(1),
 			createKlarOnAirSegment(2, {
@@ -389,8 +412,17 @@ describe('Resolve Rundown Into Playlist', () => {
 			resolvedPlaylist: literal<ResolvedPlaylist>([
 				{
 					rundownId: 'test-playlist_1',
-					segments: ['segment-01', 'segment-02', 'segment-03'],
+					segments: ['segment-01'],
+				},
+				{
+					rundownId: 'test-playlist_2',
+					segments: ['segment-02'],
 					payload: { graphicProfile: 'TV2 Nyhederne' },
+				},
+				{
+					rundownId: 'test-playlist_3',
+					segments: ['segment-03'],
+					payload: { graphicProfile: 'TV2 Sporten' },
 				},
 			]),
 			untimedSegments: new Set(['segment-02']),
@@ -426,7 +458,7 @@ describe('Resolve Rundown Into Playlist', () => {
 		})
 	})
 
-	it('tests that we only care about non-floated segments (kommando)', () => {
+	it('tests that we only care about non-floated segments', () => {
 		const segments = [
 			createUnrankedSegment(1),
 			createKlarOnAirSegment(2, {
@@ -445,7 +477,11 @@ describe('Resolve Rundown Into Playlist', () => {
 			resolvedPlaylist: literal<ResolvedPlaylist>([
 				{
 					rundownId: 'test-playlist_1',
-					segments: ['segment-01', 'segment-02', 'segment-03'],
+					segments: ['segment-01', 'segment-02'],
+				},
+				{
+					rundownId: 'test-playlist_2',
+					segments: ['segment-03'],
 					payload: { graphicProfile: 'TV2 Sporten' },
 				},
 			]),


### PR DESCRIPTION
Makes the gateway provide rundown ranks in rundown payload, so that the blueprints can use it to give core the right order.
Contains all the changes from https://github.com/tv2/inews-ftp-gateway/pull/45, with conflicts resolved