### PR TITLE
iNewsGateway no longer remove DesignCues if the Segment has a layout

### DIFF
--- a/src/classes/RundownManager.ts
+++ b/src/classes/RundownManager.ts
@@ -133,29 +133,8 @@ export class RundownManager {
 	}
 
 	private addDesignLayoutCueToStory(story: INewsStory): void {
-		this.removeDesignCueFromBody(story)
 		const cueIndex = this.addCueToStory(story, 'DESIGN_LAYOUT')
 		this.addLinkToStory(story, cueIndex)
-	}
-
-	private removeDesignCueFromBody(story: INewsStory): void {
-		const designCueIndex = story.cues.findIndex((c) => c && c.some((s) => s.includes('DESIGN')))
-		if (designCueIndex < 0) {
-			return
-		}
-		const lines = story.body!.split('<p>')
-		const index = lines.findIndex((s) => s.includes(`<\a idref="${designCueIndex}">`))
-		if (index < 0) {
-			return
-		}
-		lines.splice(index, 1)
-		story.body = this.reassembleBody(lines)
-	}
-
-	private reassembleBody(lines: string[]): string {
-		return lines.reduce((previousValue, currentValue) => {
-			return `${previousValue}<p>${currentValue}`
-		})
 	}
 
 	/**
@@ -178,6 +157,12 @@ export class RundownManager {
 			`<\a idref="${layoutCueIndex}"></a></p>\r\n`,
 			...afterPrimaryCueHalf,
 		])
+	}
+
+	private reassembleBody(lines: string[]): string {
+		return lines.reduce((previousValue, currentValue) => {
+			return `${previousValue}<p>${currentValue}`
+		})
 	}
 
 	/**

--- a/src/classes/__tests__/RundownManager.spec.ts
+++ b/src/classes/__tests__/RundownManager.spec.ts
@@ -65,28 +65,6 @@ describe('RundownManager', () => {
 			expect(lines[index + 1]).toMatch(/<a(.*?)<\/a>/i)
 		})
 
-		it('already have design cue, remove link to cue', () => {
-			const body = '<p></p>\r\n</p><p><a idref="0"></a></p>'
-			const designCueFromBody = ['KG=DESIGN_OL']
-			const story = createStory(LAYOUT, body)
-			story.cues.push(designCueFromBody)
-
-			testee.generateCuesFromLayoutField(story)
-
-			expect(story.body!.match(/<\a idref="0"><\/a>/i)).toBeFalsy()
-		})
-
-		it('already have design cue, but no layout, dont remove link to cue', () => {
-			const body = '<p></p>\r\n</p><p><a idref="0"></a></p>'
-			const designCueFromBody = ['KG=DESIGN_OL']
-			const story = createStory(undefined, body)
-			story.cues.push(designCueFromBody)
-
-			testee.generateCuesFromLayoutField(story)
-
-			expect(story.body!.match(/<\a idref="0"><\/a>/i)).toBeTruthy()
-		})
-
 		it('adds a DESIGN_BG to cues', () => {
 			const story = createStory(LAYOUT)
 


### PR DESCRIPTION
The logic for deciding to use the design from the Design cue or from the layout should be in Blueprints because if there is no configuration for the layout in the blueprint, then we should fallback on the Design cue. This is not possible to know from the iNewsGateway. Therefore we need to send both cues from the iNewsGateway in order for Blueprints to decide which to use.