### PR TITLE
fix: (SOF-878) reduced logs in production by lowering logging level from info to debug.

### DIFF
--- a/src/classes/RundownWatcher.ts
+++ b/src/classes/RundownWatcher.ts
@@ -227,7 +227,7 @@ export class RundownWatcher extends EventEmitter {
 
 	private watch() {
 		this.stopPollTimer()
-		this.logger.info('Check rundowns for updates')
+		this.logger.debug('Checking rundowns for updates')
 
 		this.checkINewsRundowns()
 			.then(


### PR DESCRIPTION
- The changed line in RundownWatcher.watch() caused 4409 out of 4446 logs during the 24 hours log file i checked.
- Changed the log statement to indicate that it is an ongoing process, not a command.