### PR TITLE
Upgrade node to 16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12-alpine3.9
+FROM node:16-alpine3.16
 RUN apk add --no-cache tzdata git
 COPY . /opt/sofie-inews-gateway
 WORKDIR /opt/sofie-inews-gateway

--- a/package.json
+++ b/package.json
@@ -14,6 +14,10 @@
       "url": "https://github.com/stephan-nordnes-eriksen"
     }
   ],
+  "engines": {
+    "npm": ">=6.14.4",
+    "node": ">=14.0.0"
+  },
   "author": "SuperFly.tv",
   "scripts": {
     "start": "cross-env NODE_ENV=production node ./dist",


### PR DESCRIPTION
Since node12 reached EOL late 2020, it is time to say goodbye and welcome the latest stable LTS: node16.
The package will still support node14 and above, but is set to use node16 for when building docker image.