### PR TITLE
chore: SOF-1001 Update blueprints- and server-core-integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@sofie-automation/blueprints-integration": "npm:@tv2media/blueprints-integration@1.42.7",
+    "@sofie-automation/blueprints-integration": "npm:@tv2media/blueprints-integration@1.37.0-rc12",
     "@sofie-automation/server-core-integration": "npm:@tv2media/server-core-integration@42.0.0",
     "@tv2media/logger": "^1.2.3",
     "@types/dotenv": "^6.1.1",

--- a/package.json
+++ b/package.json
@@ -72,8 +72,8 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@sofie-automation/blueprints-integration": "npm:@tv2media/blueprints-integration@1.37.0-rc12",
-    "@sofie-automation/server-core-integration": "npm:@tv2media/server-core-integration@1.37.0-rc12",
+    "@sofie-automation/blueprints-integration": "npm:@tv2media/blueprints-integration@1.42.7",
+    "@sofie-automation/server-core-integration": "npm:@tv2media/server-core-integration@42.0.0",
     "@tv2media/logger": "^1.2.3",
     "@types/dotenv": "^6.1.1",
     "@types/xml2js": "^0.4.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -391,15 +391,15 @@
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-4.6.0.tgz#3c7c9c46e678feefe7a2e5bb609d3dbd665ffb3f"
   integrity sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==
 
-"@sofie-automation/blueprints-integration@npm:@tv2media/blueprints-integration@1.42.7":
-  version "1.42.7"
-  resolved "https://registry.yarnpkg.com/@tv2media/blueprints-integration/-/blueprints-integration-1.42.7.tgz#b88bc4becb27d0b5e828562286bd01cbbb1ee422"
-  integrity sha512-GAalonu3u6v4bjkM+v0IFDBdKksfMsch7GpsR7Yef7HMpFhEqQvl2rXqd9j3NyQhJKKmywG9Oh081HsvHCfOKg==
+"@sofie-automation/blueprints-integration@npm:@tv2media/blueprints-integration@1.37.0-rc12":
+  version "1.37.0-rc12"
+  resolved "https://registry.yarnpkg.com/@tv2media/blueprints-integration/-/blueprints-integration-1.37.0-rc12.tgz#92dc136930c31394abb39cf39c3b1f836388d6db"
+  integrity sha512-EMqkMv26frSSFde55leS/sz8m0NgZfmQFU2eqVegblrUpM7kNEMIdtLys5aFjrKAoPz/fRJQxRo4biFGQr7BAA==
   dependencies:
-    moment "2.29.3"
-    timeline-state-resolver-types "npm:@tv2media/timeline-state-resolver-types@2.1.3"
-    tslib "^2.3.1"
-    type-fest "^2.11.1"
+    moment "2.29.1"
+    timeline-state-resolver-types "npm:@tv2media/timeline-state-resolver-types@1.0.0-release37"
+    tslib "^2.1.0"
+    underscore "1.13.1"
 
 "@sofie-automation/server-core-integration@npm:@tv2media/server-core-integration@42.0.0":
   version "42.0.0"
@@ -4025,10 +4025,10 @@ modify-values@^1.0.0:
   resolved "https://registry.yarnpkg.com/modify-values/-/modify-values-1.0.1.tgz#b3939fa605546474e3e3e3c63d64bd43b4ee6022"
   integrity sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==
 
-moment@2.29.3:
-  version "2.29.3"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.3.tgz#edd47411c322413999f7a5940d526de183c031f3"
-  integrity sha512-c6YRvhEo//6T2Jz/vVtYzqBzwvPT95JBQ+smCytzf7c50oMZRsR/a4w88aD34I+/QVSfnoAnSBFPJHItlOMJVw==
+moment@2.29.1:
+  version "2.29.1"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
+  integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==
 
 mount-point@^3.0.0:
   version "3.0.0"
@@ -5680,12 +5680,12 @@ through@2, "through@>=2.2.7 <3":
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
 
-"timeline-state-resolver-types@npm:@tv2media/timeline-state-resolver-types@2.1.3":
-  version "2.1.3"
-  resolved "https://registry.yarnpkg.com/@tv2media/timeline-state-resolver-types/-/timeline-state-resolver-types-2.1.3.tgz#b79f4a5449428c517398bc908e93c13477ff04a8"
-  integrity sha512-wHW2S/Q/i2Dn7QPjY8nCdfjGG/a8BCvMfuI/vMm9WTqfzRnBgh9S8gd4TmOFUEaAiEZNGRy/wR6Y0ZquLYQ0mQ==
+"timeline-state-resolver-types@npm:@tv2media/timeline-state-resolver-types@1.0.0-release37":
+  version "1.0.0-release37"
+  resolved "https://registry.yarnpkg.com/@tv2media/timeline-state-resolver-types/-/timeline-state-resolver-types-1.0.0-release37.tgz#3271b202cd0c4e03ae418c76019276238eede7db"
+  integrity sha512-HdCWUQ0EJ7LwlaH9eRtURwzXknIvo3U8kInzus9Vx0M0HoUixYgfV5Z80w/PVSYdUk0L95kW2oLZB4ECB1M7Pg==
   dependencies:
-    tslib "^2.3.1"
+    tslib "^2.1.0"
 
 tmpl@1.0.5:
   version "1.0.5"
@@ -5833,6 +5833,11 @@ tslib@^2.0.0, tslib@^2.3.1:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
   integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
 
+tslib@^2.1.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
+  integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
+
 tslint-config-prettier@^1.18.0:
   version "1.18.0"
   resolved "https://registry.yarnpkg.com/tslint-config-prettier/-/tslint-config-prettier-1.18.0.tgz#75f140bde947d35d8f0d238e0ebf809d64592c37"
@@ -5912,11 +5917,6 @@ type-fest@^0.8.1:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
 
-type-fest@^2.11.1:
-  version "2.18.0"
-  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-2.18.0.tgz#fdef3a74e0a9e68ebe46054836650fb91ac3881e"
-  integrity sha512-pRS+/yrW5TjPPHNOvxhbNZexr2bS63WjrMU8a+VzEBhUi9Tz1pZeD+vQz3ut0svZ46P+SRqMEPnJmk2XnvNzTw==
-
 typedarray-to-buffer@^3.1.5:
   version "3.1.5"
   resolved "https://registry.yarnpkg.com/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz#a97ee7a9ff42691b9f783ff1bc5112fe3fca9080"
@@ -5980,7 +5980,7 @@ unbox-primitive@^1.0.1:
     has-symbols "^1.0.2"
     which-boxed-primitive "^1.0.2"
 
-underscore@^1.12.1, underscore@^1.9.1:
+underscore@1.13.1, underscore@^1.12.1, underscore@^1.9.1:
   version "1.13.1"
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.13.1.tgz#0c1c6bd2df54b6b69f2314066d65b6cde6fcf9d1"
   integrity sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g==

--- a/yarn.lock
+++ b/yarn.lock
@@ -391,26 +391,26 @@
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-4.6.0.tgz#3c7c9c46e678feefe7a2e5bb609d3dbd665ffb3f"
   integrity sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==
 
-"@sofie-automation/blueprints-integration@npm:@tv2media/blueprints-integration@1.37.0-rc12":
-  version "1.37.0-rc12"
-  resolved "https://registry.yarnpkg.com/@tv2media/blueprints-integration/-/blueprints-integration-1.37.0-rc12.tgz#92dc136930c31394abb39cf39c3b1f836388d6db"
-  integrity sha512-EMqkMv26frSSFde55leS/sz8m0NgZfmQFU2eqVegblrUpM7kNEMIdtLys5aFjrKAoPz/fRJQxRo4biFGQr7BAA==
+"@sofie-automation/blueprints-integration@npm:@tv2media/blueprints-integration@1.42.7":
+  version "1.42.7"
+  resolved "https://registry.yarnpkg.com/@tv2media/blueprints-integration/-/blueprints-integration-1.42.7.tgz#b88bc4becb27d0b5e828562286bd01cbbb1ee422"
+  integrity sha512-GAalonu3u6v4bjkM+v0IFDBdKksfMsch7GpsR7Yef7HMpFhEqQvl2rXqd9j3NyQhJKKmywG9Oh081HsvHCfOKg==
   dependencies:
-    moment "2.29.1"
-    timeline-state-resolver-types "npm:@tv2media/timeline-state-resolver-types@1.0.0-release37"
-    tslib "^2.1.0"
-    underscore "1.13.1"
+    moment "2.29.3"
+    timeline-state-resolver-types "npm:@tv2media/timeline-state-resolver-types@2.1.3"
+    tslib "^2.3.1"
+    type-fest "^2.11.1"
 
-"@sofie-automation/server-core-integration@npm:@tv2media/server-core-integration@1.37.0-rc12":
-  version "1.37.0-rc12"
-  resolved "https://registry.yarnpkg.com/@tv2media/server-core-integration/-/server-core-integration-1.37.0-rc12.tgz#03a875ff798b51165dcb2bb73fd9b99defe0a53f"
-  integrity sha512-gZLkuDGHlmXXOaCLdsHEB991aO5bAhtsn8qEKZNARYBd4ODV61n25Cyj3UV7EImfDNsQEm/FL4jPnOS0fG+dMQ==
+"@sofie-automation/server-core-integration@npm:@tv2media/server-core-integration@42.0.0":
+  version "42.0.0"
+  resolved "https://registry.yarnpkg.com/@tv2media/server-core-integration/-/server-core-integration-42.0.0.tgz#9ab343e6238bc55402d9646ecabdd789ea9d24bf"
+  integrity sha512-C4471JoQsHOYvM2bIFXuXR062xhK5PeoYJpfeyfMTAZW76tNw0UkP4idKc8U0x2aUqYpmXjiSwsaHjdUVD7xBA==
   dependencies:
     data-store "^4.0.3"
-    ejson "^2.2.0"
+    ejson "^2.2.2"
     faye-websocket "^0.11.4"
-    got "^11.8.2"
-    tslib "^2.0.3"
+    got "^11.8.5"
+    tslib "^2.3.1"
     underscore "^1.12.1"
 
 "@stroncium/procfs@^1.0.0":
@@ -1757,10 +1757,10 @@ ecc-jsbn@~0.1.1:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
 
-ejson@^2.2.0:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/ejson/-/ejson-2.2.1.tgz#53569bdf3a60013f5dc206e0f9640b64cd674acc"
-  integrity sha512-Tah5TfXynM7dCqnI/YyyI93/vN0hwXQrimNNzXIKmhr11vGrVtXhzwZ4Gyx+AHb4FqJa0YQORoaKnJHRB1TnwQ==
+ejson@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/ejson/-/ejson-2.2.2.tgz#095bf356a57295784cada6ff19b2b2abc70e4f9d"
+  integrity sha512-Wc/PZH7WMxuM6eBpAuD9+IX98q27hlBTD8nvhh7UyGy22eB9qTRG0oAzlviicADh9VVxYp+/onTyfYZC3DhI5w==
 
 electron-to-chromium@^1.4.17:
   version "1.4.49"
@@ -2388,7 +2388,7 @@ globby@^7.1.1:
     pify "^3.0.0"
     slash "^1.0.0"
 
-got@^11.8.2:
+got@^11.8.5:
   version "11.8.5"
   resolved "https://registry.yarnpkg.com/got/-/got-11.8.5.tgz#ce77d045136de56e8f024bebb82ea349bc730046"
   integrity sha512-o0Je4NvQObAuZPHLFoRSkdG2lTgtcynqymzg2Vupdx6PorhaT5MCbIyXG6d4D94kk8ZG57QeosgdiqfJWhEhlQ==
@@ -4025,10 +4025,10 @@ modify-values@^1.0.0:
   resolved "https://registry.yarnpkg.com/modify-values/-/modify-values-1.0.1.tgz#b3939fa605546474e3e3e3c63d64bd43b4ee6022"
   integrity sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==
 
-moment@2.29.1:
-  version "2.29.1"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
-  integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==
+moment@2.29.3:
+  version "2.29.3"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.3.tgz#edd47411c322413999f7a5940d526de183c031f3"
+  integrity sha512-c6YRvhEo//6T2Jz/vVtYzqBzwvPT95JBQ+smCytzf7c50oMZRsR/a4w88aD34I+/QVSfnoAnSBFPJHItlOMJVw==
 
 mount-point@^3.0.0:
   version "3.0.0"
@@ -5680,12 +5680,12 @@ through@2, "through@>=2.2.7 <3":
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
 
-"timeline-state-resolver-types@npm:@tv2media/timeline-state-resolver-types@1.0.0-release37":
-  version "1.0.0-release37"
-  resolved "https://registry.yarnpkg.com/@tv2media/timeline-state-resolver-types/-/timeline-state-resolver-types-1.0.0-release37.tgz#3271b202cd0c4e03ae418c76019276238eede7db"
-  integrity sha512-HdCWUQ0EJ7LwlaH9eRtURwzXknIvo3U8kInzus9Vx0M0HoUixYgfV5Z80w/PVSYdUk0L95kW2oLZB4ECB1M7Pg==
+"timeline-state-resolver-types@npm:@tv2media/timeline-state-resolver-types@2.1.3":
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/@tv2media/timeline-state-resolver-types/-/timeline-state-resolver-types-2.1.3.tgz#b79f4a5449428c517398bc908e93c13477ff04a8"
+  integrity sha512-wHW2S/Q/i2Dn7QPjY8nCdfjGG/a8BCvMfuI/vMm9WTqfzRnBgh9S8gd4TmOFUEaAiEZNGRy/wR6Y0ZquLYQ0mQ==
   dependencies:
-    tslib "^2.1.0"
+    tslib "^2.3.1"
 
 tmpl@1.0.5:
   version "1.0.5"
@@ -5828,7 +5828,7 @@ tslib@^1.7.1, tslib@^1.8.0, tslib@^1.8.1:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.0.0, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.3.1:
+tslib@^2.0.0, tslib@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
   integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
@@ -5912,6 +5912,11 @@ type-fest@^0.8.1:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
 
+type-fest@^2.11.1:
+  version "2.18.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-2.18.0.tgz#fdef3a74e0a9e68ebe46054836650fb91ac3881e"
+  integrity sha512-pRS+/yrW5TjPPHNOvxhbNZexr2bS63WjrMU8a+VzEBhUi9Tz1pZeD+vQz3ut0svZ46P+SRqMEPnJmk2XnvNzTw==
+
 typedarray-to-buffer@^3.1.5:
   version "3.1.5"
   resolved "https://registry.yarnpkg.com/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz#a97ee7a9ff42691b9f783ff1bc5112fe3fca9080"
@@ -5975,7 +5980,7 @@ unbox-primitive@^1.0.1:
     has-symbols "^1.0.2"
     which-boxed-primitive "^1.0.2"
 
-underscore@1.13.1, underscore@^1.12.1, underscore@^1.9.1:
+underscore@^1.12.1, underscore@^1.9.1:
   version "1.13.1"
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.13.1.tgz#0c1c6bd2df54b6b69f2314066d65b6cde6fcf9d1"
   integrity sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g==


### PR DESCRIPTION
Blueprints-integration already had a publish 1.42.7 version, so I used that. 
For Server-core-integration I had to publish a new version since 1.37.0-rc12 was the latest we had.
I went with the version number 42.0.0 since pre-fixing with a 1 is Superflys standard, not ours. 