### PR TITLE
fix: Non-empty floated segment causes empty rundown.

### DIFF
--- a/src/helpers/ResolveRundownIntoPlaylist.ts
+++ b/src/helpers/ResolveRundownIntoPlaylist.ts
@@ -29,6 +29,8 @@ export function ResolveRundownIntoPlaylist(
 	const splitRundown = () => {
 		const isAllSegmentsForCurrentRundownEmpty = currentRundown.segments
 			.map((segmentExternalId) => segments.find((segment) => segment.externalId === segmentExternalId))
+			.filter(isSegment)
+			.filter((segment) => !isSegmentFloated(segment))
 			.every(isSegmentEmpty)
 
 		if (currentRundown.segments.length === 0 || isAllSegmentsForCurrentRundownEmpty) return
@@ -84,10 +86,15 @@ export function ResolveRundownIntoPlaylist(
 	return { resolvedPlaylist, untimedSegments }
 }
 
-function isSegmentEmpty(segment: UnrankedSegment | undefined): boolean {
-	if (segment === undefined) {
-		return true
-	}
+function isSegment(segment: UnrankedSegment | undefined): segment is UnrankedSegment {
+	return segment !== undefined
+}
+
+function isSegmentFloated(segment: UnrankedSegment): boolean {
+	return segment.iNewsStory.meta.float === 'float'
+}
+
+function isSegmentEmpty(segment: UnrankedSegment): boolean {
 	const isCuesEmpty = segment.iNewsStory.cues.length === 0
 	return isCuesEmpty && isSegmentBodyEmpty(segment)
 }

--- a/src/helpers/__tests__/ResolveRundownIntoPlaylist.spec.ts
+++ b/src/helpers/__tests__/ResolveRundownIntoPlaylist.spec.ts
@@ -558,4 +558,32 @@ describe('Resolve Rundown Into Playlist', () => {
 			untimedSegments: new Set(['segment-03']),
 		})
 	})
+
+	it('tests that showstyle splits correctly even when having a non-empty floated segment prior.', () => {
+		const segments = [
+			createUnrankedSegment(1, {
+				body: '<p><a idref="0" /></p>',
+				meta: { float: true },
+			}),
+			createKlarOnAirSegment(2, {
+				cues: ['SOFIE=SHOWSTYLEVARIANT\nTV2 Nyhederne'.split('\n')],
+				body: '<p><a idref="0" /></p>',
+			}),
+			createKlarOnAirSegment(3, {
+				body: '<p><a idref="0" /></p>',
+			}),
+		]
+		const resolvedPlayList = ResolveRundownIntoPlaylist('test-playlist', segments)
+
+		expect(resolvedPlayList).toEqual({
+			resolvedPlaylist: literal<ResolvedPlaylist>([
+				{
+					rundownId: 'test-playlist_1',
+					segments: ['segment-01', 'segment-02', 'segment-03'],
+					payload: { showstyleVariant: 'TV2 Nyhederne', rank: 0 },
+				},
+			]),
+			untimedSegments: new Set(['segment-02']),
+		})
+	})
 })


### PR DESCRIPTION
Having a non-empty floated segment before the first showstyle variant
made the rundown split and hereby possibly creating an undesired empty rundown.

Same as https://github.com/tv2/inews-ftp-gateway/pull/55, but with Jira tag in branch name.