### PR TITLE
Fix logger methods crashing when used as first order functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
   "dependencies": {
     "@sofie-automation/blueprints-integration": "npm:@tv2media/blueprints-integration@1.37.0-rc12",
     "@sofie-automation/server-core-integration": "npm:@tv2media/server-core-integration@42.0.0",
-    "@tv2media/logger": "^1.2.3",
+    "@tv2media/logger": "^1.2.4",
     "@types/dotenv": "^6.1.1",
     "@types/xml2js": "^0.4.4",
     "async-mutex": "^0.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -440,10 +440,10 @@
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
   integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
 
-"@tv2media/logger@^1.2.3":
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/@tv2media/logger/-/logger-1.2.3.tgz#7f305badae4907071c1672d462e62604b1e1f137"
-  integrity sha512-iyBLaBkl9QtF1qqSWgA4cyrKZX3RQlCuLxMxgym0vMGxuyEbouw4DMZYhsmEZliqKSnwLsWmkhh+wEZ5Aiacdg==
+"@tv2media/logger@^1.2.4":
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/@tv2media/logger/-/logger-1.2.4.tgz#44a3c36e76da34c3c6501d08f33ab563e11cb9ea"
+  integrity sha512-6IE5U2dZEsmHYvpdSMnoS0HHArEDBfAJELkvBwSEKQNFo05SJh26VcG4b7UB+w35+dO6bKkmJjbMwaZ80NBF5Q==
 
 "@types/babel__core@^7.1.0":
   version "7.1.18"


### PR DESCRIPTION
The logger methods (info, warn, error, ...) can now be used as first-order functions.