### PR TITLE
fix: SOF-1104 Update metaData now has higher priority than updateSegm…

### DIFF
--- a/src/helpers/DiffPlaylist.ts
+++ b/src/helpers/DiffPlaylist.ts
@@ -53,6 +53,11 @@ export interface PlaylistChangeRundownCreated extends PlaylistChangeBase {
 	rundownExternalId: string
 }
 
+export interface PlaylistChangeRundownUpdated extends PlaylistChangeBase {
+	type: PlaylistChangeType.PlaylistChangeRundownUpdated
+	rundownExternalId: string
+}
+
 export interface PlaylistChangeRundownMetaDataUpdated extends PlaylistChangeBase {
 	type: PlaylistChangeType.PlaylistChangeRundownMetaDataUpdated
 	rundownExternalId: string
@@ -66,6 +71,7 @@ export type PlaylistChange =
 	| PlaylistChangeRundownCreated
 	| PlaylistChangeRundownDeleted
 	| PlaylistChangeRundownMetaDataUpdated
+	| PlaylistChangeRundownUpdated
 
 export type SegmentChanges = {
 	// rundownId: changes
@@ -131,6 +137,12 @@ export function DiffPlaylist(
 		}
 
 		if (prevRundown.payload?.showstyleVariant !== rundown.payload?.showstyleVariant) {
+			changes.push(
+				literal<PlaylistChangeRundownUpdated>({
+					type: PlaylistChangeType.PlaylistChangeRundownUpdated,
+					rundownExternalId: rundown.externalId,
+				})
+			)
 			updatedRundownMetaData.add(rundown.externalId)
 		}
 

--- a/src/helpers/GenerateCoreCalls.ts
+++ b/src/helpers/GenerateCoreCalls.ts
@@ -5,9 +5,6 @@ import { literal } from '../helpers'
 import { logger } from '../logger'
 import {
 	PlaylistChange,
-	PlaylistChangeRundownCreated,
-	PlaylistChangeRundownDeleted,
-	PlaylistChangeRundownMetaDataUpdated,
 	PlaylistChangeSegmentChanged,
 	PlaylistChangeSegmentCreated,
 	PlaylistChangeSegmentDeleted,
@@ -15,7 +12,7 @@ import {
 	PlaylistChangeType,
 } from './DiffPlaylist'
 import { PlaylistId, RundownId, SegmentId } from './id'
-import { ResolvedPlaylist } from './ResolveRundownIntoPlaylist'
+import { ResolvedPlaylist, ResolvedPlaylistRundown } from './ResolveRundownIntoPlaylist'
 import { RundownSegment } from '../classes/datastructures/Segment'
 
 export enum CoreCallType {
@@ -95,145 +92,59 @@ export function GenerateCoreCalls(
 	ingestCacheData: Map<SegmentId, RundownSegment>,
 	untimedSegments: Set<SegmentId>
 ): CoreCall[] {
-	const calls: CoreCall[] = []
+	const coreCalls: CoreCall[] = []
 
-	const playlistDeletedRundowns: PlaylistChangeRundownDeleted[] = changes.filter(
-		(f) => f.type === PlaylistChangeType.PlaylistChangeRundownDeleted
-	) as PlaylistChangeRundownDeleted[]
-	let playlistCreatedRundowns: PlaylistChangeRundownCreated[] = changes.filter(
-		(f) => f.type === PlaylistChangeType.PlaylistChangeRundownCreated
-	) as PlaylistChangeRundownCreated[]
-	let playlistUpdatedRundownMetaData: PlaylistChangeRundownMetaDataUpdated[] = changes.filter(
-		(f) => f.type === PlaylistChangeType.PlaylistChangeRundownMetaDataUpdated
-	) as PlaylistChangeRundownMetaDataUpdated[]
-	let playlistChangedSegments: Array<
-		PlaylistChangeSegmentMoved | PlaylistChangeSegmentCreated | PlaylistChangeSegmentChanged
-	> = changes.filter((f) => f.type === PlaylistChangeType.PlaylistChangeSegmentChanged) as Array<
-		PlaylistChangeSegmentMoved | PlaylistChangeSegmentCreated | PlaylistChangeSegmentChanged
-	>
-	let playlistDeletedSegments: PlaylistChangeSegmentDeleted[] = changes.filter(
-		(f) => f.type === PlaylistChangeType.PlaylistChangeSegmentDeleted
-	) as PlaylistChangeSegmentDeleted[]
-	let playlistCreatedSegments: PlaylistChangeSegmentCreated[] = changes.filter(
-		(f) => f.type === PlaylistChangeType.PlaylistChangeSegmentCreated
-	) as PlaylistChangeSegmentCreated[]
-	let playlistMovedSegments: PlaylistChangeSegmentMoved[] = changes.filter(
-		(f) => f.type === PlaylistChangeType.PlaylistChangeSegmentMoved
-	) as PlaylistChangeSegmentMoved[]
-
-	for (let rundown of playlistDeletedRundowns) {
-		logger.debug(`Adding core call: Rundown delete (${rundown.rundownExternalId})`)
-		calls.push(
-			literal<CoreCallRundownDelete>({
-				type: CoreCallType.dataRundownDelete,
-				rundownExternalId: rundown.rundownExternalId,
-			})
-		)
-	}
-
-	for (let deletedSegment of playlistDeletedSegments) {
-		logger.debug(`Adding core call: Segment delete (${deletedSegment.segmentExternalId})`)
-		calls.push(
-			literal<CoreCallSegmentDelete>({
-				type: CoreCallType.dataSegmentDelete,
-				rundownExternalId: deletedSegment.rundownExternalId,
-				segmentExternalId: deletedSegment.segmentExternalId,
-			})
-		)
-	}
-
-	for (let createdRundown of playlistCreatedRundowns) {
-		logger.debug(`Creating rundown: ${createdRundown.rundownExternalId}`)
-		const assignedRundown = playlistAssignments.find((r) => r.rundownId === createdRundown.rundownExternalId)
-
-		if (!assignedRundown) {
-			logger.error(
-				`Tried to create rundown ${createdRundown.rundownExternalId} but could not find the segments associated with this rundown.`
-			)
-			continue
-		}
-
-		const rundown = playlistRundownToIngestRundown(
+	coreCalls.push(...createDeletedRundownCoreCalls(changes))
+	coreCalls.push(...createSegmentDeletedCoreCalls(changes))
+	coreCalls.push(
+		...createRundownCreateCoreCalls(
+			changes,
+			playlistAssignments,
 			playlistId,
-			assignedRundown.rundownId,
-			assignedRundown.segments,
-			assignedRundown.payload,
 			iNewsDataCache,
 			assignedRanks,
 			untimedSegments
 		)
-
-		logger.debug(`Adding core call: Rundown create (${rundown.externalId})`)
-		calls.push(
-			literal<CoreCallRundownCreate>({
-				type: CoreCallType.dataRundownCreate,
-				rundownExternalId: rundown.externalId,
-				rundown,
-			})
+	)
+	coreCalls.push(
+		...createMetaDataUpdateCoreCalls(
+			changes,
+			playlistAssignments,
+			playlistId,
+			iNewsDataCache,
+			assignedRanks,
+			untimedSegments
 		)
-	}
-
-	for (const changedSegment of playlistChangedSegments) {
-		const segmentId = changedSegment.segmentExternalId
-		const rundownId = changedSegment.rundownExternalId
-		const inews = iNewsDataCache.get(changedSegment.segmentExternalId)
-		let rank = assignedRanks.get(segmentId)
-		const cachedData = ingestCacheData.get(segmentId)
-		const untimed = untimedSegments.has(segmentId)
-
-		if (!inews) {
-			logger.error(`Could not process segment change ${segmentId}, iNews data could not be found`)
-			continue
-		}
-
-		if (rank === undefined) {
-			logger.error(`Could not assign rank to ${segmentId}, it will appear out of order`)
-			// Try to keep old position, otherwise send to top
-			rank = cachedData?.rank ?? 0
-		}
-
-		logger.debug(`Adding core call: Segment update (${segmentId})`)
-		const segment = inewsToIngestSegment(rundownId, segmentId, inews, rank, untimed)
-		calls.push(
-			literal<CoreCallSegmentUpdate>({
-				type: CoreCallType.dataSegmentUpdate,
-				rundownExternalId: rundownId,
-				segmentExternalId: segmentId,
-				segment,
-			})
+	)
+	coreCalls.push(
+		...createSegmentChangedCoreCalls(changes, iNewsDataCache, assignedRanks, ingestCacheData, untimedSegments)
+	)
+	coreCalls.push(
+		...createSegmentCreatedCoreCalls(changes, iNewsDataCache, assignedRanks, ingestCacheData, untimedSegments)
+	)
+	coreCalls.push(...createSegmentMovedCoreCalls(changes, assignedRanks, ingestCacheData))
+	coreCalls.push(
+		...createRundownUpdatedCoreCalls(
+			changes,
+			playlistAssignments,
+			playlistId,
+			iNewsDataCache,
+			assignedRanks,
+			untimedSegments
 		)
-	}
+	)
 
-	for (const createdSegment of playlistCreatedSegments) {
-		const segmentId = createdSegment.segmentExternalId
-		const rundownId = createdSegment.rundownExternalId
-		const inews = iNewsDataCache.get(createdSegment.segmentExternalId)
-		let rank = assignedRanks.get(segmentId)
-		const cachedData = ingestCacheData.get(segmentId)
-		const untimed = untimedSegments.has(segmentId)
+	return coreCalls
+}
 
-		if (!inews) {
-			logger.error(`Could not process created segment ${segmentId}, iNews data could not be found`)
-			continue
-		}
-
-		if (rank == undefined) {
-			logger.error(`Could not assign rank to ${segmentId}, it will appear out of order`)
-			// Try to keep old position, otherwise send to top
-			rank = cachedData?.rank ?? 0
-		}
-
-		logger.debug(`Adding core call: Segment create (${segmentId})`)
-		const segment = inewsToIngestSegment(rundownId, segmentId, inews, rank, untimed)
-		calls.push(
-			literal<CoreCallSegmentCreate>({
-				type: CoreCallType.dataSegmentCreate,
-				rundownExternalId: rundownId,
-				segmentExternalId: segment.externalId,
-				segment,
-			})
-		)
-	}
+function createSegmentMovedCoreCalls(
+	changes: PlaylistChange[],
+	assignedRanks: Map<SegmentId, number>,
+	ingestCacheData: Map<SegmentId, RundownSegment>
+): CoreCallSegmentRanksUpdate[] {
+	const playlistMovedSegments: PlaylistChangeSegmentMoved[] = changes.filter(
+		(playlistChange) => playlistChange.type === PlaylistChangeType.PlaylistChangeSegmentMoved
+	) as PlaylistChangeSegmentMoved[]
 
 	const updatedRanks: Map<RundownId, { [segmentId: string]: number }> = new Map()
 
@@ -254,9 +165,10 @@ export function GenerateCoreCalls(
 		updatedRanks.set(rundownId, rundownRanks)
 	}
 
+	const coreCalls: CoreCallSegmentRanksUpdate[] = []
 	for (let [rundownId, ranks] of updatedRanks) {
 		logger.debug(`Adding core call: Segment ranks update (${rundownId})`)
-		calls.push(
+		coreCalls.push(
 			literal<CoreCallSegmentRanksUpdate>({
 				type: CoreCallType.dataSegmentRanksUpdate,
 				rundownExternalId: rundownId,
@@ -265,37 +177,244 @@ export function GenerateCoreCalls(
 		)
 	}
 
-	for (const updatedRundown of playlistUpdatedRundownMetaData) {
-		const assignedRundown = playlistAssignments.find((r) => r.rundownId === updatedRundown.rundownExternalId)
+	return coreCalls
+}
 
-		if (!assignedRundown) {
-			logger.error(
-				`Tried to create rundown ${updatedRundown.rundownExternalId} but could not find the segments associated with this rundown.`
+function createDeletedRundownCoreCalls(changes: PlaylistChange[]): CoreCallRundownDelete[] {
+	return changes
+		.filter((playlistChange) => playlistChange.type === PlaylistChangeType.PlaylistChangeRundownDeleted)
+		.map((playlistChange) => {
+			logger.debug(`Adding core call: Rundown delete (${playlistChange.rundownExternalId})`)
+			return literal<CoreCallRundownDelete>({
+				type: CoreCallType.dataRundownDelete,
+				rundownExternalId: playlistChange.rundownExternalId,
+			})
+		})
+}
+
+function createSegmentDeletedCoreCalls(changes: PlaylistChange[]): CoreCallSegmentDelete[] {
+	return changes
+		.filter((playlistChange) => playlistChange.type === PlaylistChangeType.PlaylistChangeSegmentDeleted)
+		.map((playlistChange) => {
+			const playlistChangeSegmentDeleted: PlaylistChangeSegmentDeleted = playlistChange as PlaylistChangeSegmentDeleted
+			logger.debug(`Adding core call: Segment delete (${playlistChangeSegmentDeleted.segmentExternalId})`)
+			return literal<CoreCallSegmentDelete>({
+				type: CoreCallType.dataSegmentDelete,
+				rundownExternalId: playlistChangeSegmentDeleted.rundownExternalId,
+				segmentExternalId: playlistChangeSegmentDeleted.segmentExternalId,
+			})
+		})
+}
+
+function createRundownCreateCoreCalls(
+	changes: PlaylistChange[],
+	playlistAssignments: Array<ResolvedPlaylistRundown>,
+	playlistId: string,
+	iNewsDataCache: Map<SegmentId, UnrankedSegment>,
+	assignedRanks: Map<SegmentId, number>,
+	untimedSegments: Set<SegmentId>
+): CoreCallRundownCreate[] {
+	return changes
+		.filter((playlistChange) => playlistChange.type === PlaylistChangeType.PlaylistChangeRundownCreated)
+		.map((playlistChange) => {
+			logger.debug(`Creating rundown: ${playlistChange.rundownExternalId}`)
+			const assignedRundown = playlistAssignments.find(
+				(playlistAssignment) => playlistAssignment.rundownId === playlistChange.rundownExternalId
 			)
-			continue
-		}
 
-		const rundown = playlistRundownToIngestRundown(
-			playlistId,
-			assignedRundown.rundownId,
-			assignedRundown.segments,
-			assignedRundown.payload,
-			iNewsDataCache,
-			assignedRanks,
-			untimedSegments
-		)
+			if (!assignedRundown) {
+				logger.error(
+					`Tried to create rundown ${playlistChange.rundownExternalId} but could not find the segments associated with this rundown.`
+				)
+				return undefined
+			}
 
-		logger.debug(`Adding core call: Rundown metadata update (${rundown.externalId})`)
-		calls.push(
-			literal<CoreCallRundownMetaDataUpdate>({
+			const rundown = playlistRundownToIngestRundown(
+				playlistId,
+				assignedRundown.rundownId,
+				assignedRundown.segments,
+				assignedRundown.payload,
+				iNewsDataCache,
+				assignedRanks,
+				untimedSegments
+			)
+
+			logger.debug(`Adding core call: Rundown create (${rundown.externalId})`)
+			return literal<CoreCallRundownCreate>({
+				type: CoreCallType.dataRundownCreate,
+				rundownExternalId: rundown.externalId,
+				rundown,
+			})
+		})
+		.filter((coreCall): coreCall is CoreCallRundownCreate => !!coreCall)
+}
+
+function createMetaDataUpdateCoreCalls(
+	changes: PlaylistChange[],
+	playlistAssignments: Array<ResolvedPlaylistRundown>,
+	playlistId: string,
+	iNewsDataCache: Map<SegmentId, UnrankedSegment>,
+	assignedRanks: Map<SegmentId, number>,
+	untimedSegments: Set<SegmentId>
+): CoreCallRundownMetaDataUpdate[] {
+	return changes
+		.filter((playlistChange) => playlistChange.type === PlaylistChangeType.PlaylistChangeRundownMetaDataUpdated)
+		.map((playlistChange) => {
+			const assignedRundown = playlistAssignments.find((r) => r.rundownId === playlistChange.rundownExternalId)
+
+			if (!assignedRundown) {
+				logger.error(
+					`Tried to create rundown ${playlistChange.rundownExternalId} but could not find the segments associated with this rundown.`
+				)
+				return undefined
+			}
+
+			const rundown = playlistRundownToIngestRundown(
+				playlistId,
+				assignedRundown.rundownId,
+				assignedRundown.segments,
+				assignedRundown.payload,
+				iNewsDataCache,
+				assignedRanks,
+				untimedSegments
+			)
+
+			logger.debug(`Adding core call: Rundown metadata update (${rundown.externalId})`)
+			return literal<CoreCallRundownMetaDataUpdate>({
 				type: CoreCallType.dataRundownMetaDataUpdate,
 				rundownExternalId: rundown.externalId,
 				rundown,
 			})
-		)
-	}
+		})
+		.filter((coreCall): coreCall is CoreCallRundownMetaDataUpdate => !!coreCall)
+}
 
-	return calls
+function createSegmentChangedCoreCalls(
+	changes: PlaylistChange[],
+	iNewsDataCache: Map<SegmentId, UnrankedSegment>,
+	assignedRanks: Map<SegmentId, number>,
+	ingestCacheData: Map<SegmentId, RundownSegment>,
+	untimedSegments: Set<SegmentId>
+): CoreCallSegmentUpdate[] {
+	return changes
+		.filter((playlistChange) => playlistChange.type === PlaylistChangeType.PlaylistChangeSegmentChanged)
+		.map((playlistChange) => {
+			const change:
+				| PlaylistChangeSegmentMoved
+				| PlaylistChangeSegmentCreated
+				| PlaylistChangeSegmentChanged = playlistChange as
+				| PlaylistChangeSegmentMoved
+				| PlaylistChangeSegmentCreated
+				| PlaylistChangeSegmentChanged
+			const segmentId = change.segmentExternalId
+			const rundownId = change.rundownExternalId
+			const inews = iNewsDataCache.get(change.segmentExternalId)
+			let rank = assignedRanks.get(segmentId)
+			const cachedData = ingestCacheData.get(segmentId)
+			const untimed = untimedSegments.has(segmentId)
+
+			if (!inews) {
+				logger.error(`Could not process segment change ${segmentId}, iNews data could not be found`)
+				return undefined
+			}
+
+			if (rank === undefined) {
+				logger.error(`Could not assign rank to ${segmentId}, it will appear out of order`)
+				// Try to keep old position, otherwise send to top
+				rank = cachedData?.rank ?? 0
+			}
+
+			logger.debug(`Adding core call: Segment update (${segmentId})`)
+			const segment = inewsToIngestSegment(rundownId, segmentId, inews, rank, untimed)
+			return literal<CoreCallSegmentUpdate>({
+				type: CoreCallType.dataSegmentUpdate,
+				rundownExternalId: rundownId,
+				segmentExternalId: segmentId,
+				segment,
+			})
+		})
+		.filter((coreCall): coreCall is CoreCallSegmentUpdate => !!coreCall)
+}
+
+function createSegmentCreatedCoreCalls(
+	changes: PlaylistChange[],
+	iNewsDataCache: Map<SegmentId, UnrankedSegment>,
+	assignedRanks: Map<SegmentId, number>,
+	ingestCacheData: Map<SegmentId, RundownSegment>,
+	untimedSegments: Set<SegmentId>
+): CoreCallSegmentCreate[] {
+	return changes
+		.filter((playlistChange) => playlistChange.type === PlaylistChangeType.PlaylistChangeSegmentCreated)
+		.map((playlistChange) => {
+			const change: PlaylistChangeSegmentCreated = playlistChange as PlaylistChangeSegmentCreated
+			const segmentId = change.segmentExternalId
+			const rundownId = change.rundownExternalId
+			const inews = iNewsDataCache.get(change.segmentExternalId)
+			let rank = assignedRanks.get(segmentId)
+			const cachedData = ingestCacheData.get(segmentId)
+			const untimed = untimedSegments.has(segmentId)
+
+			if (!inews) {
+				logger.error(`Could not process created segment ${segmentId}, iNews data could not be found`)
+				return undefined
+			}
+
+			if (rank == undefined) {
+				logger.error(`Could not assign rank to ${segmentId}, it will appear out of order`)
+				// Try to keep old position, otherwise send to top
+				rank = cachedData?.rank ?? 0
+			}
+
+			logger.debug(`Adding core call: Segment create (${segmentId})`)
+			const segment = inewsToIngestSegment(rundownId, segmentId, inews, rank, untimed)
+			return literal<CoreCallSegmentCreate>({
+				type: CoreCallType.dataSegmentCreate,
+				rundownExternalId: rundownId,
+				segmentExternalId: segment.externalId,
+				segment,
+			})
+		})
+		.filter((coreCall): coreCall is CoreCallSegmentCreate => !!coreCall)
+}
+
+function createRundownUpdatedCoreCalls(
+	changes: PlaylistChange[],
+	playlistAssignments: Array<ResolvedPlaylistRundown>,
+	playlistId: string,
+	iNewsDataCache: Map<SegmentId, UnrankedSegment>,
+	assignedRanks: Map<SegmentId, number>,
+	untimedSegments: Set<SegmentId>
+): CoreCallRundownUpdate[] {
+	return changes
+		.filter((playlistChange) => playlistChange.type === PlaylistChangeType.PlaylistChangeRundownUpdated)
+		.map((playlistChange) => {
+			const assignedRundown = playlistAssignments.find((r) => r.rundownId === playlistChange.rundownExternalId)
+
+			if (!assignedRundown) {
+				logger.error(
+					`Tried to create rundown ${playlistChange.rundownExternalId} but could not find the segments associated with this rundown.`
+				)
+				return undefined
+			}
+
+			const rundown = playlistRundownToIngestRundown(
+				playlistId,
+				assignedRundown.rundownId,
+				assignedRundown.segments,
+				assignedRundown.payload,
+				iNewsDataCache,
+				assignedRanks,
+				untimedSegments
+			)
+
+			logger.debug(`Adding core call: Rundown updated (${rundown.externalId})`)
+			return literal<CoreCallRundownUpdate>({
+				type: CoreCallType.dataRundownUpdate,
+				rundownExternalId: rundown.externalId,
+				rundown,
+			})
+		})
+		.filter((coreCall): coreCall is CoreCallRundownUpdate => !!coreCall)
 }
 
 function playlistRundownToIngestRundown(

--- a/src/helpers/__tests__/DiffPlaylist.spec.ts
+++ b/src/helpers/__tests__/DiffPlaylist.spec.ts
@@ -3,6 +3,7 @@ import {
 	PlaylistChangeRundownCreated,
 	PlaylistChangeRundownDeleted,
 	PlaylistChangeRundownMetaDataUpdated,
+	PlaylistChangeRundownUpdated,
 	PlaylistChangeSegmentCreated,
 	PlaylistChangeSegmentDeleted,
 	PlaylistChangeSegmentMoved,
@@ -552,48 +553,17 @@ describe('DiffPlaylist', () => {
 	})
 
 	it('tests if adding a showstyle variant triggers update meta data', () => {
-		let prevPlaylist = [
-			makeINewsRundown('test-rundown_1', [
-				{
-					_id: 'segment-01',
-				},
-				{
-					_id: 'segment-02',
-				},
-				{
-					_id: 'segment-03',
-				},
-			]),
-		]
+		const prevPlaylist = createPlaylistWithDefaultSegments('test-rundown_1')
+		const newPlaylist = createPlaylistWithDefaultSegments('test-rundown_1', 'TV2 Nyhederne')
 
-		let newPlaylist = [
-			makeINewsRundown(
-				'test-rundown_1',
-				[
-					{
-						_id: 'segment-01',
-					},
-					{
-						_id: 'segment-02',
-					},
-					{
-						_id: 'segment-03',
-					},
-				],
-				{
-					showstyleVariant: 'TV2 Nyhederne',
-				}
-			),
-		]
+		const result = DiffPlaylist(newPlaylist, prevPlaylist)
 
-		let result = DiffPlaylist(newPlaylist, prevPlaylist)
-
-		expect(result.changes).toEqual([
+		expect(result.changes).toContainEqual(
 			literal<PlaylistChangeRundownMetaDataUpdated>({
 				type: PlaylistChangeType.PlaylistChangeRundownMetaDataUpdated,
 				rundownExternalId: 'test-rundown_1',
-			}),
-		])
+			})
+		)
 		expect(result.segmentChanges.get('test-rundown_1')).toEqual({
 			movedSegments: [],
 			notMovedSegments: ['segment-01', 'segment-02', 'segment-03'],
@@ -604,47 +574,10 @@ describe('DiffPlaylist', () => {
 	})
 
 	it('tests that keeping a showstyle variant does not trigger any updates.', () => {
-		let prevPlaylist = [
-			makeINewsRundown(
-				'test-rundown_1',
-				[
-					{
-						_id: 'segment-01',
-					},
-					{
-						_id: 'segment-02',
-					},
-					{
-						_id: 'segment-03',
-					},
-				],
-				{
-					showstyleVariant: 'TV2 Nyhederne',
-				}
-			),
-		]
+		const prevPlaylist = createPlaylistWithDefaultSegments('test-rundown_1', 'TV2 Nyhederne')
+		const newPlaylist = createPlaylistWithDefaultSegments('test-rundown_1', 'TV2 Nyhederne')
 
-		let newPlaylist = [
-			makeINewsRundown(
-				'test-rundown_1',
-				[
-					{
-						_id: 'segment-01',
-					},
-					{
-						_id: 'segment-02',
-					},
-					{
-						_id: 'segment-03',
-					},
-				],
-				{
-					showstyleVariant: 'TV2 Nyhederne',
-				}
-			),
-		]
-
-		let result = DiffPlaylist(newPlaylist, prevPlaylist)
+		const result = DiffPlaylist(newPlaylist, prevPlaylist)
 
 		expect(result.changes).toEqual([])
 		expect(result.segmentChanges.get('test-rundown_1')).toEqual({
@@ -657,54 +590,17 @@ describe('DiffPlaylist', () => {
 	})
 
 	it('tests if changing a showstyle variant triggers update meta data', () => {
-		let prevPlaylist = [
-			makeINewsRundown(
-				'test-rundown_1',
-				[
-					{
-						_id: 'segment-01',
-					},
-					{
-						_id: 'segment-02',
-					},
-					{
-						_id: 'segment-03',
-					},
-				],
-				{
-					showstyleVariant: 'TV2 Nyhederne',
-				}
-			),
-		]
+		const prevPlaylist = createPlaylistWithDefaultSegments('test-rundown_1', 'TV2 Nyhederne')
+		const newPlaylist = createPlaylistWithDefaultSegments('test-rundown_1', 'TV2 Sporten')
 
-		let newPlaylist = [
-			makeINewsRundown(
-				'test-rundown_1',
-				[
-					{
-						_id: 'segment-01',
-					},
-					{
-						_id: 'segment-02',
-					},
-					{
-						_id: 'segment-03',
-					},
-				],
-				{
-					showstyleVariant: 'TV2 Sporten',
-				}
-			),
-		]
+		const result = DiffPlaylist(newPlaylist, prevPlaylist)
 
-		let result = DiffPlaylist(newPlaylist, prevPlaylist)
-
-		expect(result.changes).toEqual([
+		expect(result.changes).toContainEqual(
 			literal<PlaylistChangeRundownMetaDataUpdated>({
 				type: PlaylistChangeType.PlaylistChangeRundownMetaDataUpdated,
 				rundownExternalId: 'test-rundown_1',
-			}),
-		])
+			})
+		)
 		expect(result.segmentChanges.get('test-rundown_1')).toEqual({
 			movedSegments: [],
 			notMovedSegments: ['segment-01', 'segment-02', 'segment-03'],
@@ -715,48 +611,17 @@ describe('DiffPlaylist', () => {
 	})
 
 	it('tests if deleting a showstyle variant triggers update meta data', () => {
-		let prevPlaylist = [
-			makeINewsRundown(
-				'test-rundown_1',
-				[
-					{
-						_id: 'segment-01',
-					},
-					{
-						_id: 'segment-02',
-					},
-					{
-						_id: 'segment-03',
-					},
-				],
-				{
-					showstyleVariant: 'TV2 Nyhederne',
-				}
-			),
-		]
+		const prevPlaylist = createPlaylistWithDefaultSegments('test-rundown_1', 'TV2 Nyhederne')
+		const newPlaylist = createPlaylistWithDefaultSegments('test-rundown_1')
 
-		let newPlaylist = [
-			makeINewsRundown('test-rundown_1', [
-				{
-					_id: 'segment-01',
-				},
-				{
-					_id: 'segment-02',
-				},
-				{
-					_id: 'segment-03',
-				},
-			]),
-		]
+		const result = DiffPlaylist(newPlaylist, prevPlaylist)
 
-		let result = DiffPlaylist(newPlaylist, prevPlaylist)
-
-		expect(result.changes).toEqual([
+		expect(result.changes).toContainEqual(
 			literal<PlaylistChangeRundownMetaDataUpdated>({
 				type: PlaylistChangeType.PlaylistChangeRundownMetaDataUpdated,
 				rundownExternalId: 'test-rundown_1',
-			}),
-		])
+			})
+		)
 		expect(result.segmentChanges.get('test-rundown_1')).toEqual({
 			movedSegments: [],
 			notMovedSegments: ['segment-01', 'segment-02', 'segment-03'],
@@ -766,6 +631,40 @@ describe('DiffPlaylist', () => {
 		})
 	})
 
-	// it('tests that creating a ')
-	// Test for checking
+	it('triggers updateRundown when showStyleVariant changes', () => {
+		const rundownId = 'test-rundown_1'
+		const playlist = createPlaylistWithDefaultSegments(rundownId, 'TV2 Nyhederne')
+		const updatedPlaylist = createPlaylistWithDefaultSegments(rundownId, 'TV2 Sporten')
+
+		const result = DiffPlaylist(playlist, updatedPlaylist)
+
+		expect(result.changes).toContainEqual(
+			literal<PlaylistChangeRundownUpdated>({
+				type: PlaylistChangeType.PlaylistChangeRundownUpdated,
+				rundownExternalId: rundownId,
+			})
+		)
+	})
 })
+
+function createPlaylistWithDefaultSegments(rundownId: string, showstyleVariant?: string): INewsRundown[] {
+	return [
+		makeINewsRundown(
+			rundownId,
+			[
+				{
+					_id: 'segment-01',
+				},
+				{
+					_id: 'segment-02',
+				},
+				{
+					_id: 'segment-03',
+				},
+			],
+			{
+				showstyleVariant,
+			}
+		),
+	]
+}

--- a/src/helpers/__tests__/GenerateCoreCalls.spec.ts
+++ b/src/helpers/__tests__/GenerateCoreCalls.spec.ts
@@ -1,0 +1,79 @@
+import { PlaylistChange, PlaylistChangeType } from '../DiffPlaylist'
+import { CoreCall, CoreCallType, GenerateCoreCalls } from '../GenerateCoreCalls'
+import { PlaylistId, SegmentId } from '../id'
+import { ResolvedPlaylist } from '../ResolveRundownIntoPlaylist'
+import { UnrankedSegment } from '../../classes/RundownWatcher'
+import { literal } from '../../helpers'
+import { INewsFields, INewsStory } from 'inews'
+
+describe('GenerateCoreCalls', () => {
+	it('generates metaData calls before segment updated calls', () => {
+		const rundownExternalId: string = 'rundownExternalId'
+		const segmentExternalId: string = 'segmentExternalId'
+		const changes: PlaylistChange[] = [
+			{
+				type: PlaylistChangeType.PlaylistChangeRundownMetaDataUpdated,
+				rundownExternalId,
+			},
+			{
+				type: PlaylistChangeType.PlaylistChangeSegmentChanged,
+				rundownExternalId,
+				segmentExternalId,
+			},
+		]
+		const playlistId: PlaylistId = 'playlistId'
+		const playlistAssignments: ResolvedPlaylist = [
+			{
+				rundownId: rundownExternalId,
+				segments: [],
+			},
+		]
+
+		const assignedRanks: Map<SegmentId, number> = new Map()
+		assignedRanks.set(segmentExternalId, 1)
+
+		const iNewsDataCache: Map<SegmentId, UnrankedSegment> = new Map<SegmentId, UnrankedSegment>()
+		iNewsDataCache.set(segmentExternalId, {
+			rundownId: '',
+			locator: '',
+			externalId: '',
+			name: '',
+			modified: new Date(),
+			iNewsStory: makeINewsStory(segmentExternalId),
+		})
+
+		const result: CoreCall[] = GenerateCoreCalls(
+			playlistId,
+			changes,
+			playlistAssignments,
+			assignedRanks,
+			iNewsDataCache,
+			new Map(),
+			new Set()
+		)
+
+		expect(result).toHaveLength(2)
+		expect(result[0].type).toEqual(CoreCallType.dataRundownMetaDataUpdate)
+		expect(result[1].type).toEqual(CoreCallType.dataSegmentUpdate)
+	})
+})
+
+function makeINewsStory(id: string, backTime?: string) {
+	return literal<INewsStory>({
+		id,
+		identifier: id,
+		locator: '',
+		fields: literal<INewsFields>({
+			title: '',
+			modifyDate: '',
+			tapeTime: '',
+			audioTime: '',
+			totalTime: '',
+			cumeTime: '',
+			backTime,
+		}),
+		meta: {},
+		cues: [],
+		body: '',
+	})
+}

--- a/src/inewsHandler.ts
+++ b/src/inewsHandler.ts
@@ -204,9 +204,7 @@ export class InewsFTPHandler {
 				this._coreHandler.core.callMethod(P.methods.dataRundownUpdate, [rundown]).catch(this._logger.error)
 			})
 			.on('rundown_metadata_update', (_rundownExternalId, rundown) => {
-				this._coreHandler.core
-					.callMethodLowPrio(P.methods.dataRundownMetaDataUpdate, [rundown])
-					.catch(this._logger.error)
+				this._coreHandler.core.callMethod(P.methods.dataRundownMetaDataUpdate, [rundown]).catch(this._logger.error)
 			})
 			.on('segment_delete', (rundownExternalId, segmentId) => {
 				this._coreHandler.core


### PR DESCRIPTION
Update metaData now has higher priority than updateSegment in order to have relevant metaData changes available when ingeting the new segment. 
Emit updateRundown when showstyleVariant changes in order to reingest graphics like 'bundt' with the correct showstyleVariant

Also did a slight refactor of GenerateCoreCalls so it's no longer in one big method. The new individual methods could also use a refactor since there appears to be a lot of duplicated logic in many of them.