### PR TITLE
(SOF-1690) Sets status in core when failing to download iNews rundown.

### DIFF
--- a/src/classes/RundownManager.ts
+++ b/src/classes/RundownManager.ts
@@ -6,8 +6,8 @@ import { literal, parseModifiedDateFromInewsStoryWithFallbackToNow, ReflectPromi
 import { VERSION } from '../version'
 import { SegmentId } from '../helpers/id'
 import { ILogger } from '@tv2media/logger'
-import { CoreHandler } from "../coreHandler";
-import { StatusCode } from "@sofie-automation/shared-lib/dist/lib/status";
+import { CoreHandler } from '../coreHandler'
+import { StatusCode } from '@sofie-automation/shared-lib/dist/lib/status'
 
 function isFile(f: INewsDirItem): f is INewsFile {
 	return f.filetype === 'file'

--- a/src/classes/RundownWatcher.ts
+++ b/src/classes/RundownWatcher.ts
@@ -205,7 +205,7 @@ export class RundownWatcher extends EventEmitter {
 		super()
 		this._logger = this.logger.tag(this.constructor.name)
 
-		this.rundownManager = new RundownManager(this._logger, this.iNewsConnection)
+		this.rundownManager = new RundownManager(this._logger, this.iNewsConnection, this.coreHandler)
 
 		if (!delayStart) {
 			this.startWatcher()

--- a/src/connector.ts
+++ b/src/connector.ts
@@ -157,7 +157,7 @@ export class Connector {
 
 		this.koaRouter.post(
 			'/rundowns/:rundownName/reingest',
-			async (context: KoaContext ): Promise<void> => {
+			async (context: KoaContext): Promise<void> => {
 				const rundownName: string = context.params.rundownName
 				if (!this.iNewsFTPHandler.iNewsWatcher) {
 					context.status = 503

--- a/src/coreHandler.ts
+++ b/src/coreHandler.ts
@@ -400,8 +400,9 @@ export class CoreHandler {
 	async triggerReloadRundown(rundownId: string): Promise<IngestRundown | null> {
 		this.logger.info(`Reloading rundown: ${rundownId}`)
 		if (this.iNewsHandler?.iNewsWatcher) {
-			await this.iNewsHandler.iNewsWatcher.ResyncRundown(rundownId)
-				.catch(error => this.logger.data(error).error(`Failed reloading rundown with rundown id '${rundownId}'.`))
+			await this.iNewsHandler.iNewsWatcher
+				.ResyncRundown(rundownId)
+				.catch((error) => this.logger.data(error).error(`Failed reloading rundown with rundown id '${rundownId}'.`))
 		}
 		return null
 	}


### PR DESCRIPTION
- Removes optionality for arguments to the constructor of the `RundownManager`, as all (1) uses always supply them.
- Adds setting of status in core, at the location we are currently experiencing exceptions from.
  - The current issue is definetly an `FATAL` error, however i am unsure if all errors thrown at the location is so. 
  Perhabs it should only be set to a `BAD` status?.

Not sure how, if possible, i could test this change, if that is something we usually do for changes in this repository.